### PR TITLE
Fix process heartbeat false positives during checkpointing

### DIFF
--- a/flagscale/runner/heartbeat/monitor.py
+++ b/flagscale/runner/heartbeat/monitor.py
@@ -143,10 +143,25 @@ class HeartbeatAnalyzer:
             self._reported.discard((rank, pid, "initial_gpu_progress"))
             self._reported.discard((rank, pid, "subsequent_gpu_progress"))
 
-    def _process_age(self, state: RankState, now_s: float) -> tuple[float, str]:
+    def _process_status(self, state: RankState, now_s: float) -> tuple[float, str, str, float]:
+        source = state.heartbeat or state.progress or state.start
+        phase = str(source.get("phase") or "setup")
         if state.heartbeat_seen_s is None:
-            return now_s - state.start_seen_s, "initial_process_heartbeat"
-        return now_s - state.heartbeat_seen_s, "subsequent_process_heartbeat"
+            return (
+                now_s - state.start_seen_s,
+                "initial_process_heartbeat",
+                phase,
+                self.initial_process_timeout_s,
+            )
+        timeout_s = (
+            self.checkpoint_timeout_s if phase == "checkpointing" else self.process_timeout_s
+        )
+        return (
+            now_s - state.heartbeat_seen_s,
+            "subsequent_process_heartbeat",
+            phase,
+            timeout_s,
+        )
 
     def _progress_age(self, state: RankState, now_s: float) -> tuple[float, str, float]:
         source = state.heartbeat or state.progress or state.start
@@ -192,12 +207,12 @@ class HeartbeatAnalyzer:
             if state.ended:
                 continue
             pid = _as_int(state.start.get("pid"), -1)
-            process_age_s, process_timeout_type = self._process_age(state, now_s)
-            process_timeout_s = (
-                self.initial_process_timeout_s
-                if state.heartbeat_seen_s is None
-                else self.process_timeout_s
-            )
+            (
+                process_age_s,
+                process_timeout_type,
+                process_phase,
+                process_timeout_s,
+            ) = self._process_status(state, now_s)
             process_alive = process_age_s <= process_timeout_s
             process_key = (rank, pid, process_timeout_type)
             if not process_alive and process_key not in self._reported:
@@ -210,7 +225,9 @@ class HeartbeatAnalyzer:
                         "rank": rank,
                         "pid": pid,
                         "hostname": state.start.get("hostname"),
+                        "phase": process_phase,
                         "timeout_type": process_timeout_type,
+                        "timeout_s": process_timeout_s,
                         "heartbeat_age_s": max(0.0, process_age_s),
                         "reason": "rank_process_or_heartbeat_thread_unresponsive",
                         "confidence": "suspected",
@@ -285,12 +302,7 @@ class HeartbeatAnalyzer:
                 )
 
         for rank, state in sorted(self.ranks.items()):
-            process_age_s, _ = self._process_age(state, now_s)
-            process_timeout_s = (
-                self.initial_process_timeout_s
-                if state.heartbeat_seen_s is None
-                else self.process_timeout_s
-            )
+            process_age_s, _, _, process_timeout_s = self._process_status(state, now_s)
             process_alive = process_age_s <= process_timeout_s
             progress_age_s, phase, progress_timeout_s = self._progress_age(state, now_s)
             if state.progress_seen_s is None:

--- a/tests/unit_tests/runner/heartbeat/test_monitor.py
+++ b/tests/unit_tests/runner/heartbeat/test_monitor.py
@@ -134,6 +134,8 @@ def test_process_heartbeat_timeout_is_reported_again_after_recovery():
     ]
     assert first_findings[0]["pid"] == 42
     assert first_findings[0]["timeout_type"] == "subsequent_process_heartbeat"
+    assert first_findings[0]["phase"] == "train"
+    assert first_findings[0]["timeout_s"] == 3
 
     analyzer.ingest(
         _event("heartbeat", progress_seq=2, iteration=2, phase="train"),
@@ -215,6 +217,50 @@ def test_checkpoint_phase_uses_longer_progress_timeout():
     analyzer.ingest(_event("heartbeat", progress_seq=1, phase="checkpointing"), observed_s=10.0)
 
     assert analyzer.scan(now_s=10.0, now_unix_ns=10_000_000_000) == []
+
+
+def test_checkpoint_phase_uses_longer_process_timeout():
+    analyzer = _analyzer()
+    analyzer.ingest(_event("process_start"), observed_s=1.0)
+    analyzer.ingest(
+        _event("heartbeat", progress_seq=1, phase="checkpointing"),
+        observed_s=1.5,
+    )
+
+    assert analyzer.scan(now_s=5.0, now_unix_ns=5_000_000_000) == []
+    rank = analyzer.snapshot(5.0, 5_000_000_000)["ranks"][0]
+    assert rank["phase"] == "checkpointing"
+    assert rank["process_liveness"] == "alive"
+
+
+def test_checkpoint_process_timeout_is_reported_after_checkpoint_threshold():
+    analyzer = _analyzer()
+    analyzer.ingest(_event("process_start"), observed_s=1.0)
+    analyzer.ingest(
+        _event("heartbeat", progress_seq=1, phase="checkpointing"),
+        observed_s=1.5,
+    )
+
+    findings = analyzer.scan(now_s=22.0, now_unix_ns=22_000_000_000)
+
+    assert [finding["finding_type"] for finding in findings] == ["rank_process_heartbeat_timeout"]
+    assert findings[0]["phase"] == "checkpointing"
+    assert findings[0]["timeout_s"] == 20
+    assert findings[0]["heartbeat_age_s"] == 20.5
+    rank = analyzer.snapshot(22.0, 22_000_000_000)["ranks"][0]
+    assert rank["process_liveness"] == "stale"
+
+
+def test_checkpoint_phase_does_not_extend_initial_process_timeout():
+    analyzer = _analyzer()
+    analyzer.ingest(_event("process_start", phase="checkpointing"), observed_s=1.0)
+
+    findings = analyzer.scan(now_s=4.0, now_unix_ns=4_000_000_000)
+
+    assert [finding["finding_type"] for finding in findings] == ["rank_process_heartbeat_timeout"]
+    assert findings[0]["timeout_type"] == "initial_process_heartbeat"
+    assert findings[0]["phase"] == "checkpointing"
+    assert findings[0]["timeout_s"] == 2
 
 
 def test_rank_that_never_started_is_detected_from_expected_world_size():


### PR DESCRIPTION
### PR Category
Train

### PR Types
Bug Fixes

### PR Description
This PR fixes false `rank_process_heartbeat_timeout` findings during long-running checkpoints.

During checkpointing, GPU progress monitoring already uses `checkpoint_timeout_s`, but process-heartbeat liveness checks still use the regular `process_timeout_s`. A long checkpoint can temporarily block heartbeat publishing while the training process remains alive, causing a false timeout finding.

The main changes include:

- Use `checkpoint_timeout_s` for subsequent process-heartbeat checks when the latest rank phase is `checkpointing`.
- Continue using `initial_process_timeout_s` before the first heartbeat.
- Continue using `process_timeout_s` during regular training phases.
- Use the same phase-aware timeout logic for finding generation and status snapshots.
- Record the detected phase and applied timeout in process-heartbeat findings.
- Add tests for regular training, checkpoint grace, checkpoint timeout, and initial-heartbeat behavior.

Validation:

- All Heartbeat unit tests passed on the A100 environment: 31 passed.
- All repository pre-commit checks passed for the changed files.