### PR TITLE
[Model] Add KERV training and inference integration

### DIFF
--- a/examples/kerv/README.md
+++ b/examples/kerv/README.md
@@ -1,0 +1,168 @@
+# KERV in FlagScale
+
+This example integrates KERV training and inference into FlagScale. KERV
+accelerates vision-language-action inference with speculative action
+generation, kinematic feedback, and batched tree verification.
+
+FlagScale provides a native, model-independent KERV control path for batched
+candidate generation, verification-tree construction, relaxed acceptance,
+dynamic threshold adjustment, and Kalman completion. Model definitions,
+weights, datasets, and the optimized KERV operators remain in their public
+upstream projects and are selected through reproducible FlagScale
+configurations.
+
+## Components
+
+| Stage | Entrypoint | Purpose |
+|---|---|---|
+| Verifier LoRA | OpenVLA `vla-scripts/finetune.py` | Parameter-efficient OpenVLA adaptation |
+| Verifier full training | OpenVLA `vla-scripts/train.py` | Full FSDP OpenVLA training |
+| Draft data generation | KERV `training/generate_drafter_data.py` | Frozen-verifier supervision |
+| Drafter training | KERV `training/train_drafter.py` | One-layer speculative drafter |
+| Inference | KERV `run_kerv_libero.py` | LIBERO rollout with KERV runtime optimization |
+
+## Installation
+
+Clone FlagScale, KERV, and the official OpenVLA training repository. The
+integration was validated with KERV commit `4abb3df` and OpenVLA commit
+`c8f03f4`:
+
+```bash
+git clone https://github.com/flagos-ai/FlagScale.git
+git clone https://github.com/zhengzihaoPKU/KERV.git
+git clone https://github.com/openvla/openvla.git openvla-training
+
+git -C KERV checkout 4abb3df
+git -C openvla-training checkout c8f03f4
+
+cd FlagScale
+pip install -r ../KERV/requirements-train.txt
+pip install -e ../KERV/openvla
+pip install -e . --no-deps
+pip install "typer>=0.9" hydra-core omegaconf
+
+git clone https://github.com/Lifelong-Robot-Learning/LIBERO.git ../LIBERO
+pip install -e ../LIBERO
+```
+
+Set the source locations. These variables replace all local absolute paths:
+
+```bash
+export KERV_SOURCE_ROOT=/path/to/KERV
+export OPENVLA_SOURCE_ROOT=/path/to/openvla-training
+export KERV_BASE_CHECKPOINT=/path/to/openvla-libero-goal
+export KERV_DRAFT_CHECKPOINT=/path/to/kerv-drafter
+export KERV_DATA_ROOT=/path/to/modified_libero_rlds
+export HF_TOKEN=hf_your_token
+export LIBERO_CONFIG_PATH=/path/to/.libero
+export PYOPENGL_PLATFORM=egl
+export MUJOCO_GL=egl
+```
+
+If the container does not expose NVIDIA EGL, use an OSMesa runtime instead:
+
+```bash
+export PYOPENGL_PLATFORM=osmesa
+export MUJOCO_GL=osmesa
+export LD_LIBRARY_PATH=/path/to/osmesa/lib:${LD_LIBRARY_PATH:-}
+```
+
+## Train the verifier
+
+LoRA fine-tuning follows the official OpenVLA Hugging Face recipe:
+
+```bash
+flagscale train kerv -c examples/kerv/conf/train_verifier_lora.yaml
+```
+
+Full training follows the official OpenVLA FSDP recipe and normally requires
+eight GPUs. Set `KERV_PRISMATIC_CHECKPOINT` and a registered OpenVLA
+`KERV_VLA_CONFIG` before launching:
+
+```bash
+export KERV_TRAIN_GPUS=8
+flagscale train kerv -c examples/kerv/conf/train_verifier_full.yaml
+```
+
+## Train the drafter
+
+Generate supervision with the frozen verifier:
+
+```bash
+flagscale train kerv -c examples/kerv/conf/generate_draft_data.yaml
+```
+
+For a short pipeline check, set `KERV_MAX_SAMPLES=8`. Then train the one-layer
+drafter with the released DeepSpeed ZeRO-2 configuration:
+
+```bash
+export KERV_DRAFT_DATA=$PWD/outputs/kerv_draft_data/samples
+flagscale train kerv -c examples/kerv/conf/train_drafter.yaml
+```
+
+The drafter script writes DeepSpeed checkpoints under `state_<epoch>`. Select
+the desired `pytorch_model.bin` and place a copy of `drafter_config.json` beside
+it as `config.json` before using that directory as `KERV_DRAFT_CHECKPOINT`.
+
+## Run inference
+
+Configure LIBERO and run one BF16-safe KERV rollout:
+
+```bash
+export LIBERO_CONFIG_PATH=$HOME/.libero
+export KERV_MAX_TASKS=1
+export KERV_TRIALS=1
+flagscale inference kerv -c examples/kerv/conf/inference.yaml
+```
+
+The default BF16 profile keeps KERV's acceptance rule, Kalman logic, model
+precision, and action definition unchanged. It enables the 14 integrated KERV
+operators from the checked-out `runtime_opt` package, including static-tree
+packing and attention, Verify-Accept control, KV commit, QKV fusion,
+Gate-Up-SwiGLU fusion, and RoPE/KV write.
+
+## Native runtime and CI smoke
+
+The model-independent control path is directly importable from
+`flagscale.models.kerv`. It has no checkpoint dependency and is covered by the
+multi-platform unit-test suite:
+
+```bash
+pytest tests/unit_tests/models/kerv -v
+```
+
+The CUDA functional test runs real candidate generation, static-tree
+construction, verification, and acceptance on the current GPU, then compares
+its output with a checked-in golden result:
+
+```bash
+flagscale inference kerv \
+  -c tests/functional_tests/inference/kerv/conf/native_runtime_smoke.yaml \
+  --test
+
+pytest tests/test_utils/runners/check_results.py::test_inference_equal \
+  --path tests/functional_tests --task inference --model kerv \
+  --case native_runtime_smoke
+```
+
+## Configuration check
+
+Configuration composition does not require weights:
+
+```bash
+flagscale train kerv -c examples/kerv/conf/train_verifier_lora.yaml --dryrun
+flagscale inference kerv -c examples/kerv/conf/inference.yaml --dryrun
+```
+
+`--dryrun` checks FlagScale configuration composition. Running the generated
+stage with `--dry-run` additionally validates the source checkout, entrypoint,
+and rendered KERV arguments without loading model weights.
+
+## Upstream references
+
+- [KERV](https://github.com/zhengzihaoPKU/KERV)
+- [OpenVLA](https://github.com/openvla/openvla)
+- [SpecVLA](https://github.com/PineTreeWss/SpecVLA)
+
+KERV and OpenVLA include their own license and third-party notices. This
+FlagScale integration is released under the FlagScale Apache-2.0 license.

--- a/examples/kerv/conf/generate_draft_data.yaml
+++ b/examples/kerv/conf/generate_draft_data.yaml
@@ -1,0 +1,26 @@
+# Copyright 2026 FlagOS Contributors
+# Licensed under the Apache License, Version 2.0.
+
+defaults:
+  - _self_
+  - train: draft_data
+
+experiment:
+  exp_name: kerv_draft_data
+  exp_dir: outputs/${experiment.exp_name}
+  task:
+    type: train
+    backend: native
+    entrypoint: flagscale/train/train_kerv.py
+  runner:
+    hostfile: null
+    nproc_per_node: 1
+    rdzv_backend: static
+  envs:
+    CUDA_VISIBLE_DEVICES: ${oc.env:CUDA_VISIBLE_DEVICES,0}
+
+action: run
+
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra

--- a/examples/kerv/conf/inference.yaml
+++ b/examples/kerv/conf/inference.yaml
@@ -1,0 +1,27 @@
+# Copyright 2026 FlagOS Contributors
+# Licensed under the Apache License, Version 2.0.
+
+defaults:
+  - _self_
+  - inference: kerv
+
+experiment:
+  exp_name: kerv_inference
+  exp_dir: outputs/${experiment.exp_name}
+  task:
+    type: inference
+    backend: vllm
+    entrypoint: flagscale/inference/inference_kerv.py
+  runner:
+    hostfile: null
+  envs:
+    CUDA_VISIBLE_DEVICES: ${oc.env:CUDA_VISIBLE_DEVICES,0}
+    LIBERO_CONFIG_PATH: ${oc.env:LIBERO_CONFIG_PATH,./.libero}
+    PYOPENGL_PLATFORM: ${oc.env:PYOPENGL_PLATFORM,egl}
+    MUJOCO_GL: ${oc.env:MUJOCO_GL,egl}
+
+action: run
+
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra

--- a/examples/kerv/conf/inference/kerv.yaml
+++ b/examples/kerv/conf/inference/kerv.yaml
@@ -1,0 +1,81 @@
+# BF16-safe KERV inference profile. Model weights are supplied by environment.
+kerv:
+  stage: inference
+  source_root: ${oc.env:KERV_SOURCE_ROOT,./KERV}
+  entrypoint: openvla/experiments/robot/libero/run_kerv_libero.py
+  launcher: python
+  work_dir: .
+  python_paths:
+    - ${oc.env:KERV_SOURCE_ROOT,./KERV}/openvla
+    - ${oc.env:KERV_SOURCE_ROOT,./KERV}/runtime_opt
+  dependencies:
+    - torch
+    - transformers
+    - draccus
+    - libero
+    - KERVRuntimeOptimization
+  env:
+    LIBERO_CONFIG_PATH: ${oc.env:LIBERO_CONFIG_PATH,./.libero}
+    PYOPENGL_PLATFORM: ${oc.env:PYOPENGL_PLATFORM,egl}
+    MUJOCO_GL: ${oc.env:MUJOCO_GL,egl}
+  arguments:
+    model_family: openvla
+    pretrained_checkpoint: ${oc.env:KERV_BASE_CHECKPOINT,./checkpoints/openvla-libero-goal}
+    spec_checkpoint: ${oc.env:KERV_DRAFT_CHECKPOINT,./checkpoints/kerv-drafter}
+    task_suite_name: ${oc.env:KERV_TASK_SUITE,libero_goal}
+    num_trials_per_task: ${oc.env:KERV_TRIALS,1}
+    max_tasks: ${oc.env:KERV_MAX_TASKS,1}
+    max_episode_steps: ${oc.env:KERV_MAX_EPISODE_STEPS,220}
+    max_planning_steps: ${oc.env:KERV_MAX_EPISODE_STEPS,220}
+    num_steps_wait: 10
+    center_crop: true
+    use_spec: true
+    use_kalman_fallback: true
+    use_kalman_tree: true
+    use_wandb: false
+    local_log_dir: ${experiment.exp_dir}/rollouts
+    run_id_note: flagscale-bf16-safe
+    use_flagos_embodied_ops: true
+    flagos_embodied_ops_include: kerv_silu_mul,kerv_add_rms_norm,kerv_verify_accept_control,kerv_static_tree_pack,kerv_static_tree_attention,kerv_action_projection_select,kerv_kv_commit,kerv_tree_embed_pack,kerv_rope_kv_store,kerv_action_verify_accept,kerv_draft_action_topk,kerv_kv_accept_commit,kerv_vision_add_layer_norm,kerv_vision_bias_gelu
+    flagos_embodied_ops_backend: auto
+    flagos_embodied_ops_strict: true
+    use_flagos_linear_fusion: true
+    flagos_qkv_fusion_rows: 8,160,192,212,220,221,224,228,229,230,232,236,239,240,241,243,248,249,250,256
+    flagos_gate_up_fusion_rows: 192,240,248,249,256,257,258,264,279,280,320
+    flagos_qkv_fusion_input_sizes: 4096,1024,1152
+    flagos_gate_up_fusion_input_sizes: 4096,1024,1152
+    flagos_swiglu_fusion_rows: 8
+    flagos_swiglu_fusion_input_sizes: 4096,1024,1152
+    flagos_swiglu_fusion_backend: native_inplace
+    flagos_linear_fusion_record: false
+    use_flagos_rope_fusion: true
+    flagos_rope_resident_key_write: true
+    flagos_rope_fusion_record: false
+    use_flagos_tree_builder: true
+    flagos_tree_static_runtime: true
+    flagos_tree_verify_max_paths: 48
+    # The public runtime uses the portable static-tree path. The optional
+    # flagos_kerv C++ extension is not required by this FlagScale profile.
+    flagos_tree_operatorized: false
+    flagos_kalman_batch: true
+    flagos_tree_node_buckets: 224,240,248,256,264,280,320
+    flagos_compile_verifier: true
+    flagos_compile_verifier_mode: cuda-graph
+    flagos_cuda_graph_max_entries: 7
+    flagos_persistent_runtime: true
+    flagos_resident_kv_cache: true
+    flagos_persistent_prefix_capacity: 288
+    flagos_persistent_tree_capacity: 320
+    flagos_fixed_workspace_layout: true
+    flagos_prewarm_graph_buckets: true
+    flagos_persistent_input_buffers: true
+    flagos_static_tree_attention: auto
+    flagos_timing_backend: cuda_event
+    flagos_system_optimization: true
+    flagos_prompt_cuda_graph: auto
+    flagos_draft_cuda_graph: auto
+    flagos_shared_graph_pool: true
+    flagos_process_level_warmup: true
+    flagos_persistent_control_buffer: true
+    flagos_persistent_decode_workspace: true
+    flagos_inference_mode: true

--- a/examples/kerv/conf/train/draft_data.yaml
+++ b/examples/kerv/conf/train/draft_data.yaml
@@ -1,0 +1,21 @@
+# Generate frozen-verifier supervision using the public KERV script.
+system: {}
+
+kerv:
+  stage: draft_data
+  source_root: ${oc.env:KERV_SOURCE_ROOT,./KERV}
+  entrypoint: training/generate_drafter_data.py
+  launcher: python
+  work_dir: .
+  python_paths:
+    - ${oc.env:KERV_SOURCE_ROOT,./KERV}/openvla
+  dependencies:
+    - torch
+    - transformers
+    - accelerate
+  arguments:
+    base-model: ${oc.env:KERV_BASE_CHECKPOINT,./checkpoints/openvla-libero-goal}
+    data-root: ${oc.env:KERV_DATA_ROOT,./datasets/modified_libero_rlds}
+    dataset-name: ${oc.env:KERV_DATASET_NAME,libero_goal_no_noops}
+    output-dir: ${experiment.exp_dir}/samples
+    max-samples: ${oc.env:KERV_MAX_SAMPLES,0}

--- a/examples/kerv/conf/train/drafter.yaml
+++ b/examples/kerv/conf/train/drafter.yaml
@@ -1,0 +1,27 @@
+# Train the one-layer KERV drafter with the released DeepSpeed ZeRO-2 recipe.
+system: {}
+
+kerv:
+  stage: drafter
+  source_root: ${oc.env:KERV_SOURCE_ROOT,./KERV}
+  entrypoint: training/train_drafter.py
+  launcher: python
+  work_dir: .
+  python_paths:
+    - ${oc.env:KERV_SOURCE_ROOT,./KERV}/openvla
+  dependencies:
+    - torch
+    - transformers
+    - deepspeed
+    - accelerate
+    - safetensors
+  arguments:
+    base-model: ${oc.env:KERV_BASE_CHECKPOINT,./checkpoints/openvla-libero-goal}
+    data-dir: ${oc.env:KERV_DRAFT_DATA,./outputs/kerv_draft_data/samples}
+    output-dir: ${experiment.exp_dir}/checkpoints
+    drafter-config: ${oc.env:KERV_SOURCE_ROOT,./KERV}/training/drafter_config.json
+    epochs: 200
+    save-every: 10
+    wandb-project: KERV-Drafter
+    wandb-mode: ${oc.env:WANDB_MODE,offline}
+    deepspeed_config: ${oc.env:KERV_SOURCE_ROOT,./KERV}/training/deepspeed_zero2.json

--- a/examples/kerv/conf/train/verifier_full.yaml
+++ b/examples/kerv/conf/train/verifier_full.yaml
@@ -1,0 +1,24 @@
+# OpenVLA full verifier training, following the official FSDP recipe.
+system: {}
+
+kerv:
+  stage: verifier_full
+  source_root: ${oc.env:OPENVLA_SOURCE_ROOT,./openvla}
+  entrypoint: vla-scripts/train.py
+  launcher: python
+  work_dir: .
+  dependencies:
+    - torch
+    - transformers
+    - draccus
+  arguments:
+    pretrained_checkpoint: ${oc.env:KERV_PRISMATIC_CHECKPOINT,./checkpoints/openvla-7b-prismatic/latest-checkpoint.pt}
+    hf_token: ${oc.env:KERV_HF_TOKEN_ENV,HF_TOKEN}
+    vla.type: ${oc.env:KERV_VLA_CONFIG,prism-dinosiglip-224px+mx-bridge}
+    data_root_dir: ${oc.env:KERV_DATA_ROOT,./datasets/open-x-embodiment}
+    run_root_dir: ${experiment.exp_dir}
+    run_id: kerv-openvla-full
+    image_aug: true
+    save_interval: 2500
+    is_resume: false
+    wandb_project: KERV-Verifier

--- a/examples/kerv/conf/train/verifier_lora.yaml
+++ b/examples/kerv/conf/train/verifier_lora.yaml
@@ -1,0 +1,29 @@
+# OpenVLA LoRA verifier training, following the official OpenVLA recipe.
+system: {}
+
+kerv:
+  stage: verifier_lora
+  source_root: ${oc.env:OPENVLA_SOURCE_ROOT,./openvla}
+  entrypoint: vla-scripts/finetune.py
+  launcher: python
+  work_dir: .
+  dependencies:
+    - torch
+    - transformers
+    - draccus
+  arguments:
+    vla_path: ${oc.env:KERV_BASE_CHECKPOINT,openvla/openvla-7b}
+    data_root_dir: ${oc.env:KERV_DATA_ROOT,./datasets/open-x-embodiment}
+    dataset_name: ${oc.env:KERV_DATASET_NAME,libero_goal_no_noops}
+    run_root_dir: ${experiment.exp_dir}
+    adapter_tmp_dir: ${experiment.exp_dir}/adapter-tmp
+    lora_rank: 32
+    lora_dropout: 0.0
+    batch_size: 16
+    grad_accumulation_steps: 1
+    learning_rate: 5.0e-4
+    image_aug: true
+    use_lora: true
+    use_quantization: false
+    wandb_project: KERV-Verifier
+    run_id_note: kerv-libero-goal

--- a/examples/kerv/conf/train_drafter.yaml
+++ b/examples/kerv/conf/train_drafter.yaml
@@ -1,0 +1,27 @@
+# Copyright 2026 FlagOS Contributors
+# Licensed under the Apache License, Version 2.0.
+
+defaults:
+  - _self_
+  - train: drafter
+
+experiment:
+  exp_name: kerv_drafter
+  exp_dir: outputs/${experiment.exp_name}
+  task:
+    type: train
+    backend: native
+    entrypoint: flagscale/train/train_kerv.py
+  runner:
+    hostfile: null
+    nproc_per_node: ${oc.env:KERV_TRAIN_GPUS,4}
+    rdzv_backend: static
+  envs:
+    CUDA_VISIBLE_DEVICES: ${oc.env:CUDA_VISIBLE_DEVICES,'0,1,2,3'}
+    WANDB_MODE: ${oc.env:WANDB_MODE,offline}
+
+action: run
+
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra

--- a/examples/kerv/conf/train_verifier_full.yaml
+++ b/examples/kerv/conf/train_verifier_full.yaml
@@ -1,0 +1,27 @@
+# Copyright 2026 FlagOS Contributors
+# Licensed under the Apache License, Version 2.0.
+
+defaults:
+  - _self_
+  - train: verifier_full
+
+experiment:
+  exp_name: kerv_verifier_full
+  exp_dir: outputs/${experiment.exp_name}
+  task:
+    type: train
+    backend: native
+    entrypoint: flagscale/train/train_kerv.py
+  runner:
+    hostfile: null
+    nproc_per_node: ${oc.env:KERV_TRAIN_GPUS,8}
+    rdzv_backend: static
+  envs:
+    CUDA_VISIBLE_DEVICES: ${oc.env:CUDA_VISIBLE_DEVICES,'0,1,2,3,4,5,6,7'}
+    WANDB_MODE: ${oc.env:WANDB_MODE,offline}
+
+action: run
+
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra

--- a/examples/kerv/conf/train_verifier_lora.yaml
+++ b/examples/kerv/conf/train_verifier_lora.yaml
@@ -1,0 +1,27 @@
+# Copyright 2026 FlagOS Contributors
+# Licensed under the Apache License, Version 2.0.
+
+defaults:
+  - _self_
+  - train: verifier_lora
+
+experiment:
+  exp_name: kerv_verifier_lora
+  exp_dir: outputs/${experiment.exp_name}
+  task:
+    type: train
+    backend: native
+    entrypoint: flagscale/train/train_kerv.py
+  runner:
+    hostfile: null
+    nproc_per_node: ${oc.env:KERV_TRAIN_GPUS,1}
+    rdzv_backend: static
+  envs:
+    CUDA_VISIBLE_DEVICES: ${oc.env:CUDA_VISIBLE_DEVICES,0}
+    WANDB_MODE: ${oc.env:WANDB_MODE,offline}
+
+action: run
+
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra

--- a/flagscale/inference/inference_kerv.py
+++ b/flagscale/inference/inference_kerv.py
@@ -1,0 +1,35 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FlagScale entrypoint for KERV speculative VLA inference."""
+
+import argparse
+
+from flagscale.kerv_runtime import load_kerv_task_config, run_kerv_entrypoint
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Launch KERV inference")
+    parser.add_argument("--config-path", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    config = load_kerv_task_config(args.config_path)
+    if config.stage != "inference":
+        raise ValueError(f"expected KERV inference stage, got: {config.stage}")
+    run_kerv_entrypoint(config, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/flagscale/kerv_runtime.py
+++ b/flagscale/kerv_runtime.py
@@ -1,0 +1,263 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-process adapter for the public KERV and OpenVLA entrypoints.
+
+KERV intentionally keeps its model implementation and checkpoints in their
+upstream projects.  FlagScale owns orchestration: it loads the composed task
+configuration, prepares the Python environment and invokes the configured
+Python entrypoint in the current worker process.  This avoids a second,
+unmanaged ``subprocess`` launcher while keeping the upstream source checkout
+replaceable.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import inspect
+import os
+import runpy
+import shlex
+import sys
+from collections.abc import Mapping, Sequence
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from omegaconf import DictConfig, OmegaConf
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+class KERVEntrypointError(RuntimeError):
+    """Raised when FlagScale cannot invoke a configured KERV entrypoint."""
+
+
+def load_kerv_task_config(config_path: str | Path) -> DictConfig:
+    """Load either a composed FlagScale config or a standalone KERV section."""
+
+    config = OmegaConf.load(config_path)
+    if config.get("stage") and config.get("entrypoint"):
+        kerv = config
+    elif "kerv" in config:
+        kerv = config.kerv
+    elif config.get("train") and "kerv" in config.train:
+        kerv = config.train.kerv
+    elif config.get("inference") and "kerv" in config.inference:
+        kerv = config.inference.kerv
+    else:
+        raise ValueError(
+            "KERV configuration must be a KERV task section or contain kerv, "
+            "train.kerv, or inference.kerv"
+        )
+    for required in ("stage", "source_root", "entrypoint"):
+        if not kerv.get(required):
+            raise ValueError(f"kerv.{required} is required")
+    return kerv
+
+
+def _render_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return ",".join(str(item) for item in value)
+    return str(value)
+
+
+def build_inprocess_argv(kerv: Mapping[str, Any]) -> list[str]:
+    """Translate ``kerv.arguments`` into the upstream command-line contract."""
+
+    argv: list[str] = []
+    for name, value in (kerv.get("arguments") or {}).items():
+        if value is None:
+            continue
+        if isinstance(value, Mapping):
+            raise TypeError(f"nested KERV argument is not supported: {name}")
+        argv.extend((f"--{name}", _render_value(value)))
+    return argv
+
+
+def _resolve_root(kerv: Mapping[str, Any]) -> Path:
+    source_root = kerv.get("source_root")
+    if not source_root:
+        raise KERVEntrypointError("kerv.source_root is required")
+    root = Path(str(source_root)).expanduser().resolve()
+    if not root.is_dir():
+        raise KERVEntrypointError(
+            f"KERV source checkout does not exist: {root}. "
+            "Set KERV_SOURCE_ROOT or OPENVLA_SOURCE_ROOT to a local checkout."
+        )
+    return root
+
+
+def _split_entrypoint(entrypoint: str) -> tuple[str, str | None]:
+    target, separator, function = entrypoint.rpartition(":")
+    if not separator:
+        return entrypoint, None
+    if not target or not function:
+        raise KERVEntrypointError(
+            "kerv.entrypoint must be a script path or '<module-or-script>:<function>'"
+        )
+    return target, function
+
+
+def _resolve_script(root: Path, target: str) -> Path | None:
+    candidate = Path(target).expanduser()
+    is_path = candidate.suffix == ".py" or candidate.is_absolute() or "/" in target
+    if not is_path:
+        return None
+    script = candidate.resolve() if candidate.is_absolute() else (root / candidate).resolve()
+    if not script.is_relative_to(root):
+        raise KERVEntrypointError("kerv.entrypoint must be located under kerv.source_root")
+    if not script.is_file():
+        raise KERVEntrypointError(
+            f"KERV entrypoint does not exist: {script}. "
+            "Use a released KERV/OpenVLA checkout or update kerv.entrypoint."
+        )
+    return script
+
+
+def _python_paths(kerv: Mapping[str, Any], root: Path) -> list[str]:
+    configured = [
+        str(Path(str(value)).expanduser().resolve()) for value in kerv.get("python_paths", [])
+    ]
+    return list(dict.fromkeys((str(root), *configured)))
+
+
+@contextmanager
+def _execution_context(kerv: Mapping[str, Any], root: Path, argv0: str, argv: Sequence[str]):
+    old_argv = sys.argv
+    old_path = sys.path.copy()
+    old_cwd = Path.cwd()
+    environment = {str(key): _render_value(value) for key, value in (kerv.get("env") or {}).items()}
+    python_paths = _python_paths(kerv, root)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        value for value in (*python_paths, os.environ.get("PYTHONPATH", "")) if value
+    )
+    old_environment = {key: os.environ.get(key) for key in environment}
+    work_dir = Path(str(kerv.get("work_dir") or root)).expanduser().resolve()
+    work_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        sys.argv = [argv0, *argv]
+        sys.path[:0] = python_paths
+        os.environ.update(environment)
+        os.chdir(work_dir)
+        yield
+    finally:
+        os.chdir(old_cwd)
+        sys.argv = old_argv
+        sys.path[:] = old_path
+        for key, previous in old_environment.items():
+            if previous is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = previous
+
+
+def _check_dependencies(kerv: Mapping[str, Any]) -> None:
+    dependencies = kerv.get("dependencies") or []
+    if isinstance(dependencies, str):
+        dependencies = [dependencies]
+    for module_name in dependencies:
+        try:
+            importlib.import_module(str(module_name))
+        except ModuleNotFoundError as error:
+            raise KERVEntrypointError(
+                f"KERV stage '{kerv.get('stage')}' requires Python module "
+                f"'{module_name}', but it is not installed in {sys.executable}."
+            ) from error
+
+
+def _load_script_module(script: Path) -> ModuleType:
+    module_name = f"_flagscale_kerv_{abs(hash(script))}"
+    spec = importlib.util.spec_from_file_location(module_name, script)
+    if spec is None or spec.loader is None:
+        raise KERVEntrypointError(f"cannot load KERV Python entrypoint: {script}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+def _call_function(module: ModuleType, function_name: str, entrypoint: str) -> Any:
+    function = getattr(module, function_name, None)
+    if function is None or not callable(function):
+        raise KERVEntrypointError(
+            f"KERV entrypoint function '{function_name}' was not found in {entrypoint}"
+        )
+    result = function()
+    if inspect.isawaitable(result):
+        raise KERVEntrypointError("async KERV entrypoints are not supported")
+    return result
+
+
+def _invoke(entrypoint: str, root: Path) -> Any:
+    target, function_name = _split_entrypoint(entrypoint)
+    script = _resolve_script(root, target)
+    if script is not None:
+        if function_name is None:
+            return runpy.run_path(str(script), run_name="__main__")
+        return _call_function(_load_script_module(script), function_name, entrypoint)
+    if function_name is None:
+        raise KERVEntrypointError(
+            "a dotted KERV module entrypoint must include a function, for example "
+            "'experiments.robot.libero.run_kerv_libero:eval_libero'"
+        )
+    module = importlib.import_module(target)
+    return _call_function(module, function_name, entrypoint)
+
+
+def run_kerv_entrypoint(kerv: Mapping[str, Any], *, dry_run: bool = False) -> Any:
+    """Run a KERV/OpenVLA Python entrypoint in the current FlagScale worker."""
+
+    launcher = str(kerv.get("launcher") or "python").lower()
+    if launcher != "python":
+        raise KERVEntrypointError(
+            f"in-process KERV execution does not accept launcher='{launcher}'. "
+            "Configure launcher=python; FlagScale's runner is responsible for "
+            "starting distributed workers."
+        )
+    root = _resolve_root(kerv)
+    entrypoint = str(kerv.get("entrypoint") or "")
+    if not entrypoint:
+        raise KERVEntrypointError("kerv.entrypoint is required")
+    target, _ = _split_entrypoint(entrypoint)
+    script = _resolve_script(root, target)
+    argv = build_inprocess_argv(kerv)
+    display_entrypoint = str(script) if script is not None else entrypoint
+    display = shlex.join([display_entrypoint, *argv])
+    print(
+        f"[FlagScale/KERV] stage={kerv.get('stage')} in_process={display}",
+        flush=True,
+    )
+    if dry_run:
+        return argv
+
+    try:
+        with _execution_context(kerv, root, display_entrypoint, argv):
+            _check_dependencies(kerv)
+            return _invoke(entrypoint, root)
+    except ModuleNotFoundError as error:
+        missing = error.name or "unknown"
+        raise KERVEntrypointError(
+            f"KERV stage '{kerv.get('stage')}' could not import '{missing}' while "
+            f"loading '{entrypoint}'. Install the KERV/OpenVLA dependencies in "
+            f"{sys.executable} and verify kerv.python_paths."
+        ) from error

--- a/flagscale/models/kerv/__init__.py
+++ b/flagscale/models/kerv/__init__.py
@@ -1,0 +1,49 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native KERV speculative-decoding runtime and FlagScale launch helpers."""
+
+from .launcher import build_kerv_command, launch_kerv_stage, load_kerv_config
+from .runtime import (
+    CandidateTree,
+    DraftCallable,
+    KERVConfig,
+    KERVRuntime,
+    KERVStepResult,
+    VerificationResult,
+    VerifyCallable,
+    build_candidate_tree,
+    compute_dynamic_threshold,
+    generate_candidate_tree,
+    kalman_predict,
+    verify_candidates,
+)
+
+__all__ = [
+    "CandidateTree",
+    "DraftCallable",
+    "KERVConfig",
+    "KERVRuntime",
+    "KERVStepResult",
+    "VerificationResult",
+    "VerifyCallable",
+    "build_candidate_tree",
+    "build_kerv_command",
+    "compute_dynamic_threshold",
+    "generate_candidate_tree",
+    "kalman_predict",
+    "launch_kerv_stage",
+    "load_kerv_config",
+    "verify_candidates",
+]

--- a/flagscale/models/kerv/launcher.py
+++ b/flagscale/models/kerv/launcher.py
@@ -1,0 +1,97 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compatibility helpers for the native KERV entrypoint adapter.
+
+FlagScale owns worker creation. KERV stages therefore run inside the current
+worker instead of starting a nested Python, torchrun, or DeepSpeed process.
+The command builder is retained for configuration validation and diagnostics;
+``launch_kerv_stage`` delegates to the same in-process adapter used by the
+public train and inference commands.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from flagscale.kerv_runtime import (
+    KERVEntrypointError,
+    build_inprocess_argv,
+    load_kerv_task_config,
+    run_kerv_entrypoint,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from omegaconf import DictConfig
+
+
+def load_kerv_config(config_path: str | Path) -> DictConfig:
+    """Backward-compatible alias for :func:`load_kerv_task_config`."""
+
+    return load_kerv_task_config(config_path)
+
+
+def _resolve_entrypoint(kerv: Mapping[str, Any]) -> tuple[Path, Path]:
+    root = Path(str(kerv.get("source_root") or "")).expanduser().resolve()
+    if not root.is_dir():
+        raise KERVEntrypointError(f"KERV source checkout does not exist: {root}")
+    target = str(kerv.get("entrypoint") or "").partition(":")[0]
+    script = Path(target).expanduser()
+    script = script.resolve() if script.is_absolute() else (root / script).resolve()
+    if not script.is_relative_to(root):
+        raise KERVEntrypointError("kerv.entrypoint must be located under kerv.source_root")
+    if not script.is_file():
+        raise KERVEntrypointError(f"KERV entrypoint does not exist: {script}")
+    return root, script
+
+
+def build_kerv_command(kerv: Mapping[str, Any]) -> tuple[list[str], Path, dict[str, str]]:
+    """Build a diagnostic argv for the in-process KERV stage.
+
+    The returned vector resembles a direct Python invocation, but it is never
+    executed as a child process. Distributed workers are created by the
+    FlagScale runner before the stage entrypoint is called.
+    """
+
+    launcher = str(kerv.get("launcher") or "python").lower()
+    if launcher != "python":
+        raise KERVEntrypointError(
+            f"nested launcher='{launcher}' is unsupported; configure launcher=python"
+        )
+    root, script = _resolve_entrypoint(kerv)
+    command = [sys.executable, str(script), *build_inprocess_argv(kerv)]
+    work_dir = Path(str(kerv.get("work_dir") or root)).expanduser().resolve()
+    environment = os.environ.copy()
+    python_paths = [str(root)] + [
+        str(Path(str(value)).expanduser().resolve()) for value in kerv.get("python_paths", [])
+    ]
+    environment["PYTHONPATH"] = os.pathsep.join(
+        value for value in (*python_paths, environment.get("PYTHONPATH", "")) if value
+    )
+    environment.update({str(key): str(value) for key, value in (kerv.get("env") or {}).items()})
+    return command, work_dir, environment
+
+
+def launch_kerv_stage(kerv: Mapping[str, Any], *, dry_run: bool = False) -> Any:
+    """Execute one KERV stage in the current FlagScale worker."""
+
+    return run_kerv_entrypoint(kerv, dry_run=dry_run)
+
+
+__all__ = ["build_kerv_command", "launch_kerv_stage", "load_kerv_config"]

--- a/flagscale/models/kerv/runtime.py
+++ b/flagscale/models/kerv/runtime.py
@@ -1,0 +1,616 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model-independent KERV speculative decoding runtime.
+
+This module contains the KERV control path that does not depend on OpenVLA's
+model implementation: batched candidate expansion, verification-tree layout,
+relaxed candidate acceptance, dynamic threshold adjustment, and Kalman-based
+action completion.  A VLA only needs to provide two small callables:
+
+* ``draft_fn(paths) -> logits`` proposes the next token for every path;
+* ``verify_fn(tree) -> logits`` evaluates all paths in one verifier call.
+
+Keeping the control path in FlagScale makes KERV directly importable and
+testable while leaving model weights, processors, and OpenVLA internals in
+their respective packages.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal, Protocol
+
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class DraftCallable(Protocol):
+    """Return next-token logits for equal-length candidate paths."""
+
+    def __call__(self, paths: torch.LongTensor) -> torch.Tensor: ...
+
+
+class VerifyCallable(Protocol):
+    """Return verifier logits aligned with ``tree.candidate_paths``."""
+
+    def __call__(self, tree: CandidateTree) -> torch.Tensor: ...
+
+
+@dataclass(frozen=True)
+class KERVConfig:
+    """Configuration for one model-independent KERV runtime.
+
+    ``candidate_depth`` counts tokens after the root token.  ``max_paths`` is
+    a global beam cap, not a per-parent cap.  ``token_offset`` supports a
+    verifier that projects only the contiguous action-token vocabulary.
+    """
+
+    action_dim: int = 7
+    candidate_depth: int = 7
+    top_k: int = 8
+    max_paths: int = 48
+    accept_threshold: int = 0
+    token_offset: int = 0
+    threshold_lower: int | None = None
+    threshold_schedule: Literal["linear", "exponential"] = "linear"
+    rollout_steps: int = 1
+    kalman_interval: int = 0
+    kalman_process_variance: float = 1.0
+    kalman_measurement_variance: float = 1e-3
+    kalman_history_window: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.action_dim <= 0:
+            raise ValueError("action_dim must be positive")
+        if self.candidate_depth <= 0:
+            raise ValueError("candidate_depth must be positive")
+        if self.top_k <= 0:
+            raise ValueError("top_k must be positive")
+        if self.max_paths <= 0:
+            raise ValueError("max_paths must be positive")
+        if self.accept_threshold < 0:
+            raise ValueError("accept_threshold must be non-negative")
+        if self.threshold_lower is not None:
+            if self.threshold_lower < 0:
+                raise ValueError("threshold_lower must be non-negative")
+            if self.threshold_lower > self.accept_threshold:
+                raise ValueError("threshold_lower must not exceed accept_threshold")
+        if self.rollout_steps <= 0:
+            raise ValueError("rollout_steps must be positive")
+        if self.kalman_interval < 0:
+            raise ValueError("kalman_interval must be non-negative")
+        if self.kalman_process_variance < 0:
+            raise ValueError("kalman_process_variance must be non-negative")
+        if self.kalman_measurement_variance <= 0:
+            raise ValueError("kalman_measurement_variance must be positive")
+
+
+@dataclass(frozen=True)
+class CandidateTree:
+    """A compact tree plus the path view consumed by a verifier.
+
+    Attributes:
+        tokens: Token stored at each unique node, shape ``[nodes]``.
+        parent_indices: Parent node for each node.  The root parent is ``-1``.
+        attention_mask: Ancestor mask, shape ``[1, 1, nodes, nodes]``.
+        position_ids: Tree depth for each node, shape ``[1, nodes]``.
+        path_indices: Node indices for every leaf path, padded with ``-1``.
+        candidate_paths: Token paths corresponding to ``path_indices``.
+        path_scores: Cumulative draft log probability for every path.
+    """
+
+    tokens: torch.LongTensor
+    parent_indices: torch.LongTensor
+    attention_mask: torch.Tensor
+    position_ids: torch.LongTensor
+    path_indices: torch.LongTensor
+    candidate_paths: torch.LongTensor
+    path_scores: torch.Tensor
+
+    @property
+    def device(self) -> torch.device:
+        return self.tokens.device
+
+    @property
+    def num_nodes(self) -> int:
+        return int(self.tokens.numel())
+
+    @property
+    def num_paths(self) -> int:
+        return int(self.path_indices.shape[0])
+
+    @classmethod
+    def from_paths(
+        cls,
+        paths: torch.LongTensor,
+        path_scores: torch.Tensor | None = None,
+    ) -> CandidateTree:
+        """Deduplicate equal prefixes and construct a verifier tree."""
+
+        if paths.ndim != 2 or paths.shape[0] == 0 or paths.shape[1] < 2:
+            raise ValueError("paths must have shape [num_paths, length>=2]")
+        if paths.dtype != torch.long:
+            paths = paths.to(torch.long)
+        if not torch.all(paths[:, 0] == paths[0, 0]):
+            raise ValueError("all candidate paths must share one root token")
+
+        device = paths.device
+        node_tokens = [int(paths[0, 0].item())]
+        parents = [-1]
+        prefix_to_node: dict[tuple[int, ...], int] = {
+            (node_tokens[0],): 0,
+        }
+        path_rows: list[list[int]] = []
+
+        for row in paths.detach().to("cpu").tolist():
+            node_path = [0]
+            for depth in range(1, len(row)):
+                prefix = tuple(int(token) for token in row[: depth + 1])
+                node = prefix_to_node.get(prefix)
+                if node is None:
+                    parent_prefix = prefix[:-1]
+                    parent = prefix_to_node[parent_prefix]
+                    node = len(node_tokens)
+                    prefix_to_node[prefix] = node
+                    node_tokens.append(int(row[depth]))
+                    parents.append(parent)
+                node_path.append(node)
+            path_rows.append(node_path)
+
+        tokens = torch.tensor(node_tokens, dtype=torch.long, device=device)
+        parent_indices = torch.tensor(parents, dtype=torch.long, device=device)
+        path_indices = torch.tensor(path_rows, dtype=torch.long, device=device)
+        return build_candidate_tree(
+            tokens,
+            parent_indices,
+            path_indices=path_indices,
+            path_scores=path_scores,
+        )
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Selected verification path and its accepted prefix."""
+
+    best_path: int
+    accept_length: int
+    accepted_tokens: torch.LongTensor
+    next_token: torch.LongTensor
+    predicted_tokens: torch.LongTensor
+    accept_lengths: torch.LongTensor
+
+
+@dataclass(frozen=True)
+class KERVStepResult:
+    """Output of one KERV candidate-generation and verification round."""
+
+    output_tokens: torch.LongTensor
+    tree: CandidateTree
+    verification: VerificationResult
+    threshold: int
+    used_kalman: bool
+
+
+def _validate_tree_parents(parent_indices: torch.LongTensor) -> None:
+    if parent_indices.ndim != 1 or parent_indices.numel() == 0:
+        raise ValueError("parent_indices must be a non-empty 1D tensor")
+    if int(parent_indices[0].item()) not in {-1, 0}:
+        raise ValueError("the root parent must be -1 or 0")
+    for node in range(1, int(parent_indices.numel())):
+        parent = int(parent_indices[node].item())
+        if parent < 0 or parent >= node:
+            raise ValueError("every non-root parent must precede its child")
+
+
+def _derive_leaf_paths(parent_indices: torch.LongTensor) -> torch.LongTensor:
+    parent_cpu = parent_indices.detach().to("cpu").tolist()
+    has_child = [False] * len(parent_cpu)
+    for node in range(1, len(parent_cpu)):
+        has_child[int(parent_cpu[node])] = True
+    leaves = [node for node in range(1, len(parent_cpu)) if not has_child[node]]
+    if not leaves:
+        leaves = [0]
+    paths: list[list[int]] = []
+    for leaf in leaves:
+        path = [leaf]
+        while path[-1] != 0:
+            path.append(int(parent_cpu[path[-1]]))
+        paths.append(list(reversed(path)))
+    max_length = max(len(path) for path in paths)
+    padded = [path + [-1] * (max_length - len(path)) for path in paths]
+    return torch.tensor(padded, dtype=torch.long, device=parent_indices.device)
+
+
+def build_candidate_tree(
+    candidate_tokens: torch.LongTensor,
+    parent_indices: torch.LongTensor,
+    path_indices: torch.LongTensor | None = None,
+    path_scores: torch.Tensor | None = None,
+) -> CandidateTree:
+    """Build KERV's mask, positions, retrieval indices, and path tokens.
+
+    This is deliberately device agnostic and runs on CPU, CUDA, and other
+    PyTorch backends.  Tree topology is small and can be cached by the caller.
+    """
+
+    if candidate_tokens.ndim != 1:
+        raise ValueError("candidate_tokens must be a 1D tensor")
+    if candidate_tokens.numel() != parent_indices.numel():
+        raise ValueError("candidate_tokens and parent_indices must align")
+    if candidate_tokens.device != parent_indices.device:
+        raise ValueError("candidate_tokens and parent_indices must share a device")
+    _validate_tree_parents(parent_indices)
+
+    device = candidate_tokens.device
+    node_count = int(candidate_tokens.numel())
+    parent_cpu = parent_indices.detach().to("cpu").tolist()
+    mask = torch.zeros((node_count, node_count), dtype=torch.bool, device=device)
+    positions = torch.empty((node_count,), dtype=torch.long, device=device)
+    for node in range(node_count):
+        current = node
+        depth = 0
+        while True:
+            mask[node, current] = True
+            if current == 0:
+                break
+            current = int(parent_cpu[current])
+            depth += 1
+        positions[node] = depth
+
+    if path_indices is None:
+        path_indices = _derive_leaf_paths(parent_indices)
+    else:
+        if path_indices.ndim != 2 or path_indices.shape[0] == 0:
+            raise ValueError("path_indices must have shape [num_paths, length]")
+        path_indices = path_indices.to(device=device, dtype=torch.long)
+        valid = path_indices >= 0
+        if bool(valid.any()) and int(path_indices[valid].max().item()) >= node_count:
+            raise ValueError("path_indices contains a node outside the tree")
+        if not torch.all(path_indices[:, 0] == 0):
+            raise ValueError("every path must start at the root node")
+
+    safe_indices = path_indices.clamp_min(0)
+    candidate_paths = candidate_tokens[safe_indices]
+    candidate_paths = candidate_paths.masked_fill(path_indices < 0, -1)
+    if path_scores is None:
+        path_scores = torch.zeros((path_indices.shape[0],), dtype=torch.float32, device=device)
+    else:
+        if path_scores.ndim != 1 or path_scores.shape[0] != path_indices.shape[0]:
+            raise ValueError("path_scores must contain one value per path")
+        path_scores = path_scores.to(device=device)
+
+    return CandidateTree(
+        tokens=candidate_tokens.to(torch.long),
+        parent_indices=parent_indices.to(torch.long),
+        attention_mask=mask.unsqueeze(0).unsqueeze(0),
+        position_ids=positions.unsqueeze(0),
+        path_indices=path_indices,
+        candidate_paths=candidate_paths,
+        path_scores=path_scores,
+    )
+
+
+def generate_candidate_tree(
+    draft_fn: DraftCallable,
+    root_token: int | torch.Tensor,
+    config: KERVConfig,
+    *,
+    device: torch.device | str | None = None,
+) -> CandidateTree:
+    """Generate a fixed-depth candidate tree through batched beam expansion."""
+
+    if isinstance(root_token, torch.Tensor):
+        if root_token.numel() != 1:
+            raise ValueError("root_token must contain exactly one token")
+        resolved_device = root_token.device
+        root = int(root_token.item())
+    else:
+        resolved_device = torch.device(device or "cpu")
+        root = int(root_token)
+
+    paths = torch.tensor([[root]], dtype=torch.long, device=resolved_device)
+    scores = torch.zeros((1,), dtype=torch.float32, device=resolved_device)
+    for _ in range(config.candidate_depth):
+        logits = draft_fn(paths)
+        if logits.ndim != 2 or logits.shape[0] != paths.shape[0]:
+            raise ValueError("draft_fn must return [num_paths, vocab_size] logits")
+        if logits.shape[1] == 0:
+            raise ValueError("draft_fn returned an empty vocabulary")
+        branch_count = min(config.top_k, int(logits.shape[1]))
+        log_probabilities = torch.log_softmax(logits.float(), dim=-1)
+        # Stable ordering makes equal-probability candidates deterministic:
+        # because vocabulary columns are ordered by token id, smaller ids win.
+        branch_tokens = torch.argsort(log_probabilities, dim=-1, descending=True, stable=True)[
+            :, :branch_count
+        ]
+        branch_scores = torch.gather(log_probabilities, 1, branch_tokens)
+        expanded_scores = scores[:, None] + branch_scores
+        parent_rows = torch.arange(paths.shape[0], device=paths.device)[:, None]
+        parent_rows = parent_rows.expand(-1, branch_count).reshape(-1)
+        expanded_paths = torch.cat(
+            (paths[parent_rows], branch_tokens.reshape(-1, 1).to(torch.long)),
+            dim=1,
+        )
+        expanded_scores = expanded_scores.reshape(-1)
+        keep = min(config.max_paths, int(expanded_scores.numel()))
+        order = torch.argsort(expanded_scores, descending=True, stable=True)[:keep]
+        scores = expanded_scores[order]
+        paths = expanded_paths[order]
+
+    return CandidateTree.from_paths(paths, scores)
+
+
+def verify_candidates(
+    candidate_tokens: CandidateTree | torch.LongTensor,
+    verifier_logits: torch.Tensor,
+    accept_threshold: int | float | None = 0,
+    *,
+    token_offset: int = 0,
+    scores: torch.Tensor | None = None,
+) -> VerificationResult:
+    """Select the path with the longest verifier-consistent prefix.
+
+    Candidate position zero is the shared root.  Logits at position ``i``
+    predict candidate position ``i + 1``.  Ties are resolved by input order,
+    matching KERV's priority-ordered candidate layout.  ``scores`` is accepted
+    for API compatibility and checked, but intentionally does not override
+    KERV's longest-prefix rule.
+    """
+
+    paths = (
+        candidate_tokens.candidate_paths
+        if isinstance(candidate_tokens, CandidateTree)
+        else candidate_tokens
+    )
+    if paths.ndim != 2 or paths.shape[1] < 2:
+        raise ValueError("candidate paths must have shape [num_paths, length>=2]")
+    if verifier_logits.ndim != 3:
+        raise ValueError("verifier_logits must have shape [num_paths, length, vocab]")
+    if verifier_logits.shape[0] != paths.shape[0]:
+        raise ValueError("candidate and verifier path counts differ")
+    if verifier_logits.shape[1] < paths.shape[1]:
+        raise ValueError("verifier logits must cover candidate tokens and one next-token position")
+    if scores is not None and scores.shape[0] != paths.shape[0]:
+        raise ValueError("scores must contain one value per path")
+
+    aligned_logits = verifier_logits[:, : paths.shape[1] - 1]
+    predictions = torch.argmax(aligned_logits, dim=-1).to(torch.long)
+    predictions = predictions + int(token_offset)
+    targets = paths[:, 1:].to(predictions.device)
+    valid = targets >= 0
+    threshold = 0.0 if accept_threshold is None else float(accept_threshold)
+    if threshold < 0:
+        raise ValueError("accept_threshold must be non-negative")
+    matches = valid & ((targets - predictions).abs() <= threshold)
+    accept_lengths = torch.cumprod(matches.to(torch.long), dim=1).sum(dim=1)
+    best_path_tensor = torch.argmax(accept_lengths)
+    best_path = int(best_path_tensor.item())
+    accept_length = int(accept_lengths[best_path].item())
+    accepted = paths[best_path, 1 : 1 + accept_length].to(verifier_logits.device)
+    next_token_logits = verifier_logits[best_path, accept_length]
+    next_token = torch.argmax(next_token_logits).to(torch.long) + int(token_offset)
+    return VerificationResult(
+        best_path=best_path,
+        accept_length=accept_length,
+        accepted_tokens=accepted,
+        next_token=next_token,
+        predicted_tokens=predictions,
+        accept_lengths=accept_lengths,
+    )
+
+
+def compute_dynamic_threshold(
+    step_idx: int,
+    total_steps: int,
+    start: int | float,
+    lower: int | float,
+    schedule: Literal["linear", "exponential"] = "linear",
+) -> float:
+    """Compute KERV's kinematic-aware relaxed acceptance threshold."""
+
+    step = max(int(step_idx), 0)
+    horizon = max(int(total_steps), 1)
+    start_value = float(start)
+    lower_value = float(lower)
+    if start_value < lower_value:
+        raise ValueError("start threshold must be >= lower threshold")
+    if schedule == "linear":
+        # A stretched exponential decays slowly early in the manipulation and
+        # approaches the strict lower bound near the expected final step.
+        epsilon = 1e-30
+        power = 3.0
+        tau = horizon / ((-math.log(epsilon)) ** (1.0 / power))
+        decay = math.exp(-((float(step) / tau) ** power))
+        value = lower_value + (start_value - lower_value) * decay
+    elif schedule == "exponential":
+        if start_value == 0:
+            return lower_value
+        ratio = max(0.0, min(1.0, lower_value / start_value))
+        value = start_value * (ratio ** (step / horizon))
+    else:
+        raise ValueError(f"unsupported threshold schedule: {schedule}")
+    return max(lower_value, value)
+
+
+def kalman_predict(
+    history: Sequence[float] | Sequence[Sequence[float]] | torch.Tensor,
+    *,
+    process_variance: float = 1.0,
+    measurement_variance: float = 1e-3,
+    initial_estimate_error: float = 10.0,
+) -> torch.Tensor:
+    """Predict the next scalar or action vector with independent Kalman filters."""
+
+    # The state dimension is tiny (seven for KERV) and belongs to the control
+    # path.  Running it on CPU avoids a chain of small device kernels and keeps
+    # the implementation portable to every PyTorch accelerator backend.
+    values = torch.as_tensor(history, dtype=torch.float64, device="cpu")
+    if values.numel() == 0:
+        raise ValueError("history must contain at least one observation")
+    if values.ndim == 1:
+        values = values[:, None]
+        squeeze = True
+    elif values.ndim == 2:
+        squeeze = False
+    else:
+        raise ValueError("history must have shape [steps] or [steps, dimensions]")
+    if process_variance < 0:
+        raise ValueError("process_variance must be non-negative")
+    if measurement_variance <= 0:
+        raise ValueError("measurement_variance must be positive")
+
+    estimate = values[0].clone()
+    error = torch.full_like(estimate, float(initial_estimate_error))
+    for measurement in values:
+        predicted_error = error + float(process_variance)
+        gain = predicted_error / (predicted_error + float(measurement_variance))
+        estimate = estimate + gain * (measurement - estimate)
+        error = (1.0 - gain) * predicted_error
+    estimate = estimate.to(torch.float32)
+    return estimate[0] if squeeze else estimate
+
+
+@dataclass
+class KERVRuntime:
+    """Small native orchestrator for one batched KERV verification round."""
+
+    config: KERVConfig
+    action_history: list[torch.LongTensor] = field(default_factory=list)
+
+    def reset(self) -> None:
+        """Clear rollout-local action history."""
+
+        self.action_history.clear()
+
+    def threshold_for_step(self, step_idx: int) -> int:
+        """Return the integer token-distance threshold for a rollout step."""
+
+        lower = self.config.threshold_lower
+        if lower is None:
+            return int(self.config.accept_threshold)
+        value = compute_dynamic_threshold(
+            step_idx,
+            self.config.rollout_steps,
+            self.config.accept_threshold,
+            lower,
+            self.config.threshold_schedule,
+        )
+        return int(round(value))
+
+    def _complete_with_kalman(
+        self,
+        accepted: torch.LongTensor,
+        history: Sequence[Sequence[int]] | torch.Tensor | None,
+    ) -> torch.LongTensor:
+        accepted = accepted[: self.config.action_dim]
+        remaining = self.config.action_dim - int(accepted.numel())
+        if remaining <= 0:
+            return accepted
+        source: Any = history if history is not None else self.action_history
+        if len(source) == 0:
+            fallback = (
+                accepted[-1:]
+                if accepted.numel()
+                else torch.zeros((1,), dtype=torch.long, device=accepted.device)
+            )
+            return torch.cat((accepted, fallback.expand(remaining)))
+        if isinstance(source, torch.Tensor):
+            source_tensor = source.to(dtype=torch.float32)
+        elif isinstance(source[0], torch.Tensor):
+            source_tensor = torch.stack([item.detach().to(dtype=torch.float32) for item in source])
+        else:
+            source_tensor = torch.as_tensor(source, dtype=torch.float32)
+        if self.config.kalman_history_window is not None:
+            source_tensor = source_tensor[-self.config.kalman_history_window :]
+        prediction = (
+            kalman_predict(
+                source_tensor,
+                process_variance=self.config.kalman_process_variance,
+                measurement_variance=self.config.kalman_measurement_variance,
+            )
+            .round()
+            .to(device=accepted.device, dtype=torch.long)
+        )
+        start = int(accepted.numel())
+        tail = prediction[start : start + remaining]
+        if tail.numel() < remaining:
+            fallback = (
+                tail[-1:]
+                if tail.numel()
+                else (accepted[-1:] if accepted.numel() else prediction[-1:])
+            )
+            tail = torch.cat((tail, fallback.expand(remaining - tail.numel())))
+        return torch.cat((accepted, tail))
+
+    def step(
+        self,
+        draft_fn: DraftCallable,
+        verify_fn: VerifyCallable,
+        root_token: int | torch.Tensor,
+        *,
+        step_idx: int = 0,
+        history: Sequence[Sequence[int]] | torch.Tensor | None = None,
+        force_kalman: bool | None = None,
+    ) -> KERVStepResult:
+        """Generate, verify, and optionally Kalman-complete one action round."""
+
+        tree = generate_candidate_tree(draft_fn, root_token, self.config)
+        logits = verify_fn(tree)
+        threshold = self.threshold_for_step(step_idx)
+        verification = verify_candidates(
+            tree,
+            logits,
+            threshold,
+            token_offset=self.config.token_offset,
+        )
+        if force_kalman is None:
+            interval = self.config.kalman_interval
+            use_kalman = interval > 0 and (int(step_idx) + 1) % interval == 0
+        else:
+            use_kalman = bool(force_kalman)
+        if use_kalman:
+            output = self._complete_with_kalman(verification.accepted_tokens, history)
+        else:
+            output = torch.cat((verification.accepted_tokens, verification.next_token.reshape(1)))[
+                : self.config.action_dim
+            ]
+        if output.numel() == self.config.action_dim:
+            self.action_history.append(output.detach().to("cpu"))
+        return KERVStepResult(
+            output_tokens=output,
+            tree=tree,
+            verification=verification,
+            threshold=threshold,
+            used_kalman=use_kalman,
+        )
+
+
+__all__ = [
+    "CandidateTree",
+    "DraftCallable",
+    "KERVConfig",
+    "KERVRuntime",
+    "KERVStepResult",
+    "VerificationResult",
+    "VerifyCallable",
+    "build_candidate_tree",
+    "compute_dynamic_threshold",
+    "generate_candidate_tree",
+    "kalman_predict",
+    "verify_candidates",
+]

--- a/flagscale/train/train_kerv.py
+++ b/flagscale/train/train_kerv.py
@@ -1,0 +1,38 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FlagScale entrypoint for the KERV verifier and drafter training stages."""
+
+import argparse
+
+from flagscale.kerv_runtime import load_kerv_task_config, run_kerv_entrypoint
+
+
+_TRAIN_STAGES = {"verifier_lora", "verifier_full", "draft_data", "drafter"}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Launch a KERV training stage")
+    parser.add_argument("--config-file", "--config-path", dest="config_path", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    config = load_kerv_task_config(args.config_path)
+    if config.stage not in _TRAIN_STAGES:
+        raise ValueError(f"unsupported KERV training stage: {config.stage}")
+    run_kerv_entrypoint(config, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional_tests/inference/kerv/conf/native_runtime_smoke.yaml
+++ b/tests/functional_tests/inference/kerv/conf/native_runtime_smoke.yaml
@@ -1,0 +1,35 @@
+# Copyright 2026 FlagOS Contributors
+# Licensed under the Apache License, Version 2.0.
+
+defaults:
+  - _self_
+
+experiment:
+  exp_name: kerv_native_runtime_smoke
+  exp_dir: tests/functional_tests/inference/kerv/test_results/native_runtime_smoke
+  task:
+    type: inference
+    # The inference runner currently uses its vLLM-labelled Python path for
+    # arbitrary inference entrypoints.  This smoke does not import vLLM.
+    backend: vllm
+    entrypoint: flagscale/inference/inference_kerv.py
+  runner:
+    hostfile: null
+  envs:
+    CUDA_VISIBLE_DEVICES: "0"
+
+inference:
+  kerv:
+    stage: inference
+    source_root: tests/functional_tests/inference/kerv
+    entrypoint: smoke_runtime.py:main
+    launcher: python
+    work_dir: .
+    arguments:
+      device: cuda
+
+action: test
+
+hydra:
+  run:
+    dir: ${experiment.exp_dir}/hydra

--- a/tests/functional_tests/inference/kerv/results_gold/native_runtime_smoke
+++ b/tests/functional_tests/inference/kerv/results_gold/native_runtime_smoke
@@ -1,0 +1,2 @@
+**************************************************
+KERV native runtime smoke: output=[1, 1, 9], accepted=2, device=cuda

--- a/tests/functional_tests/inference/kerv/smoke_runtime.py
+++ b/tests/functional_tests/inference/kerv/smoke_runtime.py
@@ -1,0 +1,72 @@
+# Copyright 2026 FlagOS Contributors
+# Licensed under the Apache License, Version 2.0.
+
+"""Weight-free CUDA smoke for the native KERV control path."""
+
+import argparse
+
+import torch
+
+from flagscale.models.kerv import KERVConfig, KERVRuntime
+
+
+def _draft(paths: torch.LongTensor) -> torch.Tensor:
+    logits = torch.full((paths.shape[0], 10), -20.0, device=paths.device)
+    logits[:, 1] = 20.0
+    logits[:, 2] = 19.0
+    return logits
+
+
+def _verify(tree) -> torch.Tensor:
+    paths = tree.candidate_paths
+    logits = torch.full((paths.shape[0], paths.shape[1], 10), -100.0, device=paths.device)
+    for path_index in range(paths.shape[0]):
+        for position in range(paths.shape[1] - 1):
+            token = int(paths[path_index, position + 1].item())
+            logits[path_index, position, token] = 100.0
+        logits[path_index, paths.shape[1] - 1, 9] = 100.0
+    return logits
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", default="cuda")
+    args = parser.parse_args()
+    if args.device == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("KERV CUDA functional smoke requires an available CUDA device")
+
+    device = torch.device(args.device)
+    runtime = KERVRuntime(
+        KERVConfig(
+            action_dim=3,
+            candidate_depth=2,
+            top_k=2,
+            max_paths=3,
+            accept_threshold=0,
+        )
+    )
+    result = runtime.step(
+        _draft,
+        _verify,
+        root_token=torch.tensor(0, dtype=torch.long, device=device),
+    )
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+    expected = torch.tensor([1, 1, 9], dtype=torch.long, device=device)
+    if not torch.equal(result.output_tokens, expected):
+        raise AssertionError(
+            f"unexpected KERV output: {result.output_tokens.detach().cpu().tolist()}"
+        )
+    if result.verification.accept_length != 2:
+        raise AssertionError(f"unexpected accept length: {result.verification.accept_length}")
+    if result.tree.attention_mask.device.type != device.type:
+        raise AssertionError("candidate tree did not stay on the requested device")
+
+    print("**************************************************")
+    print("KERV native runtime smoke: output=[1, 1, 9], accepted=2, device=cuda")
+    print("##################################################")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_utils/config/platforms/cuda.yaml
+++ b/tests/test_utils/config/platforms/cuda.yaml
@@ -44,6 +44,7 @@ a100:
         qwen3: ["tp2_pp2"]
       inference:
         qwen3: ["4b_tp2"]
+        kerv: ["native_runtime_smoke"]
       serve:
         qwen2_5: ["0.5b"]
     unit:

--- a/tests/unit_tests/models/kerv/test_configs.py
+++ b/tests/unit_tests/models/kerv/test_configs.py
@@ -1,0 +1,89 @@
+# Copyright 2026 FlagOS Contributors
+# Licensed under the Apache License, Version 2.0.
+
+from pathlib import Path
+
+from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
+
+from flagscale.models.kerv import build_kerv_command, load_kerv_config
+
+CONFIG_DIR = Path(__file__).resolve().parents[4] / "examples" / "kerv" / "conf"
+
+
+def _compose(name: str):
+    with initialize_config_dir(version_base=None, config_dir=str(CONFIG_DIR)):
+        return compose(config_name=name)
+
+
+def test_all_public_kerv_configs_compose(monkeypatch):
+    monkeypatch.setenv("KERV_SOURCE_ROOT", "/tmp/KERV")
+    monkeypatch.setenv("OPENVLA_SOURCE_ROOT", "/tmp/openvla")
+    names = (
+        "train_verifier_lora",
+        "train_verifier_full",
+        "generate_draft_data",
+        "train_drafter",
+        "inference",
+    )
+    for name in names:
+        config = _compose(name)
+        OmegaConf.resolve(config)
+        task_config = config.inference if name == "inference" else config.train
+        assert task_config.kerv.stage
+        assert config.experiment.task.entrypoint
+        if name != "inference":
+            assert task_config.system is not None
+            assert task_config.kerv.launcher == "python"
+
+
+def test_inference_uses_safe_profile(monkeypatch):
+    monkeypatch.setenv("KERV_SOURCE_ROOT", "/tmp/KERV")
+    config = _compose("inference")
+    OmegaConf.resolve(config)
+    arguments = config.inference.kerv.arguments
+    assert arguments.use_spec is True
+    assert arguments.use_kalman_fallback is True
+    assert arguments.use_kalman_tree is True
+    assert arguments.use_flagos_embodied_ops is True
+    assert "kerv_static_tree_attention" in arguments.flagos_embodied_ops_include
+    assert arguments.flagos_tree_operatorized is False
+    assert arguments.flagos_persistent_tree_capacity >= max(
+        int(value) for value in arguments.flagos_tree_node_buckets.split(",")
+    )
+    assert arguments.flagos_qkv_fusion_rows
+    assert arguments.flagos_gate_up_fusion_rows
+    assert arguments.flagos_swiglu_fusion_rows
+    assert arguments.flagos_linear_fusion_record is False
+    assert arguments.flagos_rope_fusion_record is False
+
+
+def test_all_public_configs_build_commands_without_weights(tmp_path, monkeypatch):
+    kerv_root = tmp_path / "KERV"
+    openvla_root = tmp_path / "openvla"
+    entrypoints = {
+        "train_verifier_lora": (openvla_root, "vla-scripts/finetune.py"),
+        "train_verifier_full": (openvla_root, "vla-scripts/train.py"),
+        "generate_draft_data": (kerv_root, "training/generate_drafter_data.py"),
+        "train_drafter": (kerv_root, "training/train_drafter.py"),
+        "inference": (
+            kerv_root,
+            "openvla/experiments/robot/libero/run_kerv_libero.py",
+        ),
+    }
+    for source_root, relative in entrypoints.values():
+        script = source_root / relative
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text("print('smoke')\n", encoding="utf-8")
+
+    monkeypatch.setenv("KERV_SOURCE_ROOT", str(kerv_root))
+    monkeypatch.setenv("OPENVLA_SOURCE_ROOT", str(openvla_root))
+    for name, (source_root, relative) in entrypoints.items():
+        config = _compose(name)
+        OmegaConf.resolve(config)
+        runner_config = config.inference if name == "inference" else config
+        config_path = tmp_path / f"{name}.yaml"
+        OmegaConf.save(runner_config, config_path)
+        kerv = load_kerv_config(config_path)
+        command, _, _ = build_kerv_command(kerv)
+        assert command[1] == str(source_root / relative)

--- a/tests/unit_tests/models/kerv/test_inprocess_entrypoint.py
+++ b/tests/unit_tests/models/kerv/test_inprocess_entrypoint.py
@@ -1,0 +1,211 @@
+# Copyright 2026 FlagOS Contributors
+# Licensed under the Apache License, Version 2.0.
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+from flagscale.inference.inference_kerv import main as inference_main
+from flagscale.kerv_runtime import (
+    KERVEntrypointError,
+    build_inprocess_argv,
+    run_kerv_entrypoint,
+)
+from flagscale.train.train_kerv import main as train_main
+
+
+def _write_function_entrypoint(root: Path, filename: str = "entry.py") -> Path:
+    entrypoint = root / filename
+    entrypoint.parent.mkdir(parents=True, exist_ok=True)
+    entrypoint.write_text(
+        "import os\n"
+        "import sys\n"
+        "from pathlib import Path\n\n"
+        "def main():\n"
+        "    output = os.environ.get('KERV_SMOKE_OUTPUT')\n"
+        "    if output:\n"
+        "        Path(output).write_text('|'.join(sys.argv[1:]), encoding='utf-8')\n"
+        "    return {\n"
+        "        'argv': list(sys.argv),\n"
+        "        'cwd': os.getcwd(),\n"
+        "        'marker': os.environ.get('KERV_SMOKE_MARKER'),\n"
+        "    }\n",
+        encoding="utf-8",
+    )
+    return entrypoint
+
+
+def _config(root: Path, entrypoint: str, **overrides):
+    values = {
+        "stage": "inference",
+        "source_root": str(root),
+        "entrypoint": entrypoint,
+        "launcher": "python",
+        "arguments": {
+            "enabled": True,
+            "buckets": [224, 240],
+            "ignored": None,
+        },
+    }
+    values.update(overrides)
+    return OmegaConf.create(values)
+
+
+def test_build_inprocess_argv_matches_upstream_cli_contract():
+    config = OmegaConf.create(
+        {
+            "arguments": {
+                "use_spec": True,
+                "tree_buckets": [224, 240, 256],
+                "threshold": 4,
+                "ignored": None,
+            }
+        }
+    )
+
+    assert build_inprocess_argv(config) == [
+        "--use_spec",
+        "True",
+        "--tree_buckets",
+        "224,240,256",
+        "--threshold",
+        "4",
+    ]
+
+
+def test_script_function_runs_in_current_process_and_restores_context(tmp_path):
+    root = tmp_path / "KERV"
+    entrypoint = _write_function_entrypoint(root)
+    work_dir = tmp_path / "work"
+    original_argv = sys.argv
+    original_cwd = Path.cwd()
+    original_path = sys.path.copy()
+    marker_before = os.environ.get("KERV_SMOKE_MARKER")
+    config = _config(
+        root,
+        f"{entrypoint.name}:main",
+        work_dir=str(work_dir),
+        env={"KERV_SMOKE_MARKER": "in-process"},
+    )
+
+    result = run_kerv_entrypoint(config)
+
+    assert result["argv"][1:] == ["--enabled", "True", "--buckets", "224,240"]
+    assert Path(result["cwd"]) == work_dir
+    assert result["marker"] == "in-process"
+    assert sys.argv is original_argv
+    assert Path.cwd() == original_cwd
+    assert sys.path == original_path
+    assert os.environ.get("KERV_SMOKE_MARKER") == marker_before
+
+
+def test_dotted_module_function_runs_from_source_checkout(tmp_path):
+    root = tmp_path / "KERV"
+    _write_function_entrypoint(root, "native_entry.py")
+    config = _config(root, "native_entry:main")
+
+    result = run_kerv_entrypoint(config)
+
+    assert result["argv"][0] == "native_entry:main"
+    assert result["argv"][1:] == ["--enabled", "True", "--buckets", "224,240"]
+    sys.modules.pop("native_entry", None)
+
+
+def test_plain_script_executes_as_main_without_subprocess(tmp_path):
+    root = tmp_path / "KERV"
+    output = tmp_path / "plain-script.txt"
+    script = root / "plain.py"
+    script.parent.mkdir(parents=True)
+    script.write_text(
+        "import os\n"
+        "import sys\n"
+        "from pathlib import Path\n"
+        "Path(os.environ['KERV_SMOKE_OUTPUT']).write_text(\n"
+        "    '|'.join(sys.argv[1:]), encoding='utf-8'\n"
+        ")\n",
+        encoding="utf-8",
+    )
+    config = _config(root, script.name, env={"KERV_SMOKE_OUTPUT": str(output)})
+
+    run_kerv_entrypoint(config)
+
+    assert output.read_text(encoding="utf-8") == ("--enabled|True|--buckets|224,240")
+
+
+def test_train_cli_executes_native_entrypoint(tmp_path, monkeypatch):
+    root = tmp_path / "OpenVLA"
+    script = _write_function_entrypoint(root)
+    output = tmp_path / "train.txt"
+    config = _config(
+        root,
+        f"{script.name}:main",
+        stage="verifier_lora",
+        env={"KERV_SMOKE_OUTPUT": str(output)},
+    )
+    config_path = tmp_path / "train.yaml"
+    OmegaConf.save(OmegaConf.create({"kerv": config}), config_path)
+    monkeypatch.setattr(sys, "argv", ["train_kerv", "--config-path", str(config_path)])
+
+    train_main()
+
+    assert output.read_text(encoding="utf-8") == ("--enabled|True|--buckets|224,240")
+
+
+def test_inference_cli_executes_native_entrypoint(tmp_path, monkeypatch):
+    root = tmp_path / "KERV"
+    script = _write_function_entrypoint(root)
+    output = tmp_path / "inference.txt"
+    config = _config(
+        root,
+        f"{script.name}:main",
+        env={"KERV_SMOKE_OUTPUT": str(output)},
+    )
+    config_path = tmp_path / "inference.yaml"
+    OmegaConf.save(OmegaConf.create({"kerv": config}), config_path)
+    monkeypatch.setattr(sys, "argv", ["inference_kerv", "--config-path", str(config_path)])
+
+    inference_main()
+
+    assert output.read_text(encoding="utf-8") == ("--enabled|True|--buckets|224,240")
+
+
+def test_dry_run_validates_configuration_without_importing_model(tmp_path):
+    root = tmp_path / "KERV"
+    root.mkdir()
+    config = _config(root, "unavailable_model.entrypoint:main")
+
+    argv = run_kerv_entrypoint(config, dry_run=True)
+
+    assert argv == ["--enabled", "True", "--buckets", "224,240"]
+
+
+def test_missing_dependency_reports_stage_and_module(tmp_path):
+    root = tmp_path / "KERV"
+    script = _write_function_entrypoint(root)
+    config = _config(
+        root,
+        f"{script.name}:main",
+        stage="drafter",
+        dependencies=["flagscale_kerv_dependency_that_does_not_exist"],
+    )
+
+    with pytest.raises(KERVEntrypointError) as error:
+        run_kerv_entrypoint(config)
+
+    message = str(error.value)
+    assert "drafter" in message
+    assert "flagscale_kerv_dependency_that_does_not_exist" in message
+
+
+def test_inprocess_entrypoint_rejects_nested_arguments_and_external_launchers(tmp_path):
+    root = tmp_path / "KERV"
+    root.mkdir()
+    with pytest.raises(TypeError, match="nested KERV argument"):
+        build_inprocess_argv({"arguments": {"nested": {"value": 1}}})
+
+    config = _config(root, "native_entry:main", launcher="torchrun")
+    with pytest.raises(KERVEntrypointError, match="launcher='torchrun'"):
+        run_kerv_entrypoint(config)

--- a/tests/unit_tests/models/kerv/test_launcher.py
+++ b/tests/unit_tests/models/kerv/test_launcher.py
@@ -1,0 +1,142 @@
+# Copyright 2026 FlagOS Contributors
+# Licensed under the Apache License, Version 2.0.
+
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+from flagscale.models.kerv import build_kerv_command, load_kerv_config
+
+
+def _make_script(root: Path, relative: str = "training/stage.py") -> Path:
+    script = root / relative
+    script.parent.mkdir(parents=True)
+    script.write_text("print('smoke')\n", encoding="utf-8")
+    return script
+
+
+def test_load_kerv_config(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "kerv:\n"
+        "  stage: inference\n"
+        f"  source_root: {tmp_path}\n"
+        "  entrypoint: run.py\n"
+        "  launcher: python\n",
+        encoding="utf-8",
+    )
+    config = load_kerv_config(config_path)
+    assert config.stage == "inference"
+
+
+def test_load_nested_native_train_config(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "train:\n"
+        "  system: {}\n"
+        "  kerv:\n"
+        "    stage: drafter\n"
+        f"    source_root: {tmp_path}\n"
+        "    entrypoint: training/run.py\n"
+        "    launcher: python\n",
+        encoding="utf-8",
+    )
+    config = load_kerv_config(config_path)
+    assert config.stage == "drafter"
+
+
+def test_python_command_and_argument_rendering(tmp_path):
+    script = _make_script(tmp_path)
+    config = OmegaConf.create(
+        {
+            "stage": "draft_data",
+            "source_root": str(tmp_path),
+            "entrypoint": str(script.relative_to(tmp_path)),
+            "launcher": "python",
+            "arguments": {"enabled": True, "buckets": [224, 240], "skip": None},
+        }
+    )
+    command, work_dir, environment = build_kerv_command(config)
+    assert command[1] == str(script)
+    assert command[-4:] == ["--enabled", "True", "--buckets", "224,240"]
+    assert work_dir == tmp_path
+    assert environment["PYTHONPATH"].split(":")[0] == str(tmp_path)
+
+
+def test_workdir_and_python_paths_are_absolute(tmp_path, monkeypatch):
+    source_root = tmp_path / "KERV"
+    _make_script(source_root)
+    runtime_root = source_root / "runtime_opt"
+    runtime_root.mkdir()
+    monkeypatch.chdir(tmp_path)
+    config = OmegaConf.create(
+        {
+            "stage": "inference",
+            "source_root": "KERV",
+            "entrypoint": "training/stage.py",
+            "launcher": "python",
+            "work_dir": ".",
+            "python_paths": ["KERV/runtime_opt"],
+        }
+    )
+    _, work_dir, environment = build_kerv_command(config)
+    assert work_dir == tmp_path
+    assert environment["PYTHONPATH"].split(":")[:2] == [
+        str(source_root),
+        str(runtime_root),
+    ]
+
+
+def test_nested_torchrun_is_rejected(tmp_path):
+    script = _make_script(tmp_path)
+    config = OmegaConf.create(
+        {
+            "stage": "verifier_lora",
+            "source_root": str(tmp_path),
+            "entrypoint": str(script.relative_to(tmp_path)),
+            "launcher": "torchrun",
+            "distributed": {"nnodes": 1, "nproc_per_node": 4, "master_port": 23456},
+        }
+    )
+    with pytest.raises(RuntimeError, match="nested launcher='torchrun'"):
+        build_kerv_command(config)
+
+
+def test_nested_deepspeed_is_rejected(tmp_path):
+    script = _make_script(tmp_path)
+    config = OmegaConf.create(
+        {
+            "stage": "drafter",
+            "source_root": str(tmp_path),
+            "entrypoint": str(script.relative_to(tmp_path)),
+            "launcher": "deepspeed",
+            "distributed": {"master_port": 23333, "include": "localhost:0,1"},
+        }
+    )
+    with pytest.raises(RuntimeError, match="nested launcher='deepspeed'"):
+        build_kerv_command(config)
+
+
+def test_entrypoint_cannot_escape_source_root(tmp_path):
+    outside = tmp_path.parent / "outside.py"
+    outside.write_text("print('outside')\n", encoding="utf-8")
+    config = {
+        "stage": "inference",
+        "source_root": str(tmp_path),
+        "entrypoint": str(outside),
+        "launcher": "python",
+    }
+    with pytest.raises(RuntimeError, match="under kerv.source_root"):
+        build_kerv_command(config)
+
+
+def test_missing_entrypoint_has_actionable_error(tmp_path):
+    config = {
+        "stage": "inference",
+        "source_root": str(tmp_path),
+        "entrypoint": "missing.py",
+        "launcher": "python",
+    }
+    with pytest.raises(RuntimeError, match="entrypoint does not exist"):
+        build_kerv_command(config)

--- a/tests/unit_tests/models/kerv/test_runtime.py
+++ b/tests/unit_tests/models/kerv/test_runtime.py
@@ -1,0 +1,214 @@
+# Copyright 2026 FlagOS Contributors
+# Licensed under the Apache License, Version 2.0.
+
+import pytest
+import torch
+
+from flagscale.models.kerv import (
+    CandidateTree,
+    KERVConfig,
+    KERVRuntime,
+    build_candidate_tree,
+    compute_dynamic_threshold,
+    generate_candidate_tree,
+    kalman_predict,
+    verify_candidates,
+)
+
+
+def _logits_for_paths(paths: torch.LongTensor, next_token: int) -> torch.Tensor:
+    vocabulary = max(int(paths.max().item()), next_token) + 2
+    logits = torch.full(
+        (paths.shape[0], paths.shape[1], vocabulary),
+        -100.0,
+        device=paths.device,
+    )
+    for path_index, path in enumerate(paths.tolist()):
+        for position, token in enumerate(path[1:]):
+            logits[path_index, position, token] = 100.0
+        logits[path_index, paths.shape[1] - 1, next_token] = 100.0
+    return logits
+
+
+def test_candidate_tree_deduplicates_prefixes_and_builds_ancestor_mask():
+    paths = torch.tensor([[10, 11, 12], [10, 11, 13], [10, 14, 15]], dtype=torch.long)
+    scores = torch.tensor([-0.1, -0.2, -0.3])
+
+    tree = CandidateTree.from_paths(paths, scores)
+
+    assert torch.equal(tree.tokens, torch.tensor([10, 11, 12, 13, 14, 15]))
+    assert torch.equal(tree.parent_indices, torch.tensor([-1, 0, 1, 1, 0, 4]))
+    assert torch.equal(
+        tree.path_indices,
+        torch.tensor([[0, 1, 2], [0, 1, 3], [0, 4, 5]]),
+    )
+    assert torch.equal(tree.candidate_paths, paths)
+    assert torch.equal(tree.position_ids, torch.tensor([[0, 1, 2, 2, 1, 2]]))
+    expected_row = torch.tensor([True, True, False, True, False, False])
+    assert torch.equal(tree.attention_mask[0, 0, 3], expected_row)
+    assert torch.equal(tree.path_scores, scores)
+
+
+def test_build_candidate_tree_derives_and_pads_leaf_paths():
+    tree = build_candidate_tree(
+        torch.tensor([10, 11, 12, 13]),
+        torch.tensor([-1, 0, 1, 0]),
+    )
+
+    assert torch.equal(tree.path_indices, torch.tensor([[0, 1, 2], [0, 3, -1]]))
+    assert torch.equal(tree.candidate_paths, torch.tensor([[10, 11, 12], [10, 13, -1]]))
+    assert tree.attention_mask.dtype == torch.bool
+    assert tuple(tree.attention_mask.shape) == (1, 1, 4, 4)
+
+
+@pytest.mark.parametrize(
+    "parents",
+    (
+        torch.tensor([1, 0]),
+        torch.tensor([-1, -1]),
+        torch.tensor([-1, 1]),
+    ),
+)
+def test_build_candidate_tree_rejects_invalid_topology(parents):
+    with pytest.raises(ValueError):
+        build_candidate_tree(torch.arange(parents.numel()), parents)
+
+
+def test_generate_candidate_tree_batches_expansion_and_has_stable_tie_break():
+    observed_shapes = []
+
+    def draft(paths):
+        observed_shapes.append(tuple(paths.shape))
+        # Equal probabilities deliberately exercise the documented token-id tie break.
+        return torch.zeros((paths.shape[0], 4), dtype=torch.float32)
+
+    config = KERVConfig(action_dim=3, candidate_depth=2, top_k=2, max_paths=3)
+    tree = generate_candidate_tree(draft, root_token=9, config=config)
+
+    assert observed_shapes == [(1, 1), (2, 2)]
+    assert torch.equal(
+        tree.candidate_paths,
+        torch.tensor([[9, 0, 0], [9, 0, 1], [9, 1, 0]]),
+    )
+    assert tree.num_paths == 3
+    assert tree.num_nodes == 6
+
+
+def test_verify_candidates_selects_longest_prefix_and_returns_next_token():
+    paths = torch.tensor([[0, 1, 2, 3], [0, 1, 4, 5], [0, 6, 7, 8]], dtype=torch.long)
+    logits = torch.full((3, 4, 10), -100.0)
+    predictions = (
+        (1, 2, 9, 7),
+        (1, 4, 5, 8),
+        (6, 9, 8, 7),
+    )
+    for path_index, tokens in enumerate(predictions):
+        for position, token in enumerate(tokens):
+            logits[path_index, position, token] = 100.0
+
+    result = verify_candidates(paths, logits)
+
+    assert result.best_path == 1
+    assert result.accept_length == 3
+    assert torch.equal(result.accepted_tokens, torch.tensor([1, 4, 5]))
+    assert result.next_token.item() == 8
+    assert torch.equal(result.accept_lengths, torch.tensor([2, 3, 1]))
+
+
+def test_verify_candidates_relaxed_threshold_and_token_offset():
+    paths = torch.tensor([[100, 102, 104], [100, 103, 105]])
+    logits = torch.full((2, 3, 8), -100.0)
+    # Projected vocabulary begins at token 100.  Path 0 is within distance one;
+    # path 1 fails at its first candidate token.
+    logits[0, 0, 1] = 10.0
+    logits[0, 1, 3] = 10.0
+    logits[0, 2, 7] = 10.0
+    logits[1, 0, 0] = 10.0
+    logits[1, 1, 5] = 10.0
+    logits[1, 2, 6] = 10.0
+
+    result = verify_candidates(paths, logits, accept_threshold=1, token_offset=100)
+
+    assert result.best_path == 0
+    assert result.accept_length == 2
+    assert torch.equal(result.accepted_tokens, torch.tensor([102, 104]))
+    assert result.next_token.item() == 107
+
+
+def test_verify_candidates_ties_use_input_order_and_require_next_token_logits():
+    paths = torch.tensor([[0, 1, 2], [0, 1, 3]])
+    logits = _logits_for_paths(paths, next_token=4)
+    result = verify_candidates(paths, logits)
+    assert result.best_path == 0
+
+    with pytest.raises(ValueError, match="next-token position"):
+        verify_candidates(paths, logits[:, :-1])
+
+
+def test_dynamic_threshold_is_bounded_and_monotonic():
+    values = [
+        compute_dynamic_threshold(step, 100, start=14, lower=5, schedule="linear")
+        for step in (0, 25, 50, 75, 100)
+    ]
+    assert values[0] == pytest.approx(14.0)
+    assert values[-1] == pytest.approx(5.0)
+    assert all(left >= right for left, right in zip(values, values[1:]))
+    assert compute_dynamic_threshold(100, 100, 10, 2, "exponential") == pytest.approx(2)
+
+
+def test_kalman_predict_handles_scalar_and_vector_history():
+    scalar = kalman_predict([5.0, 5.0, 5.0])
+    vector = kalman_predict([[1.0, 10.0], [2.0, 11.0], [3.0, 12.0]])
+
+    assert scalar.item() == pytest.approx(5.0)
+    assert tuple(vector.shape) == (2,)
+    assert 2.0 < vector[0].item() <= 3.0
+    assert 11.0 < vector[1].item() <= 12.0
+
+
+def test_native_runtime_executes_draft_verify_and_kalman_paths():
+    config = KERVConfig(
+        action_dim=3,
+        candidate_depth=2,
+        top_k=2,
+        max_paths=3,
+        accept_threshold=0,
+    )
+    runtime = KERVRuntime(config)
+
+    def draft(paths):
+        logits = torch.full((paths.shape[0], 10), -20.0)
+        logits[:, 1] = 20.0
+        logits[:, 2] = 19.0
+        return logits
+
+    def verify(tree):
+        return _logits_for_paths(tree.candidate_paths, next_token=9)
+
+    direct = runtime.step(draft, verify, root_token=0)
+    assert torch.equal(direct.output_tokens, torch.tensor([1, 1, 9]))
+    assert direct.verification.accept_length == 2
+    assert direct.used_kalman is False
+
+    completed = runtime.step(
+        draft,
+        verify,
+        root_token=0,
+        history=torch.tensor([[10, 20, 30], [12, 22, 32]]),
+        force_kalman=True,
+    )
+    assert torch.equal(completed.output_tokens[:2], torch.tensor([1, 1]))
+    assert completed.output_tokens[2].item() == 32
+    assert completed.used_kalman is True
+
+    runtime.reset()
+    assert runtime.action_history == []
+
+
+def test_config_rejects_invalid_runtime_parameters():
+    with pytest.raises(ValueError, match="action_dim"):
+        KERVConfig(action_dim=0)
+    with pytest.raises(ValueError, match="threshold_lower"):
+        KERVConfig(accept_threshold=2, threshold_lower=3)
+    with pytest.raises(ValueError, match="measurement_variance"):
+        KERVConfig(kalman_measurement_variance=0)


### PR DESCRIPTION
### PR Category

Train / Inference

### PR Types

New Features

### PR Description

This PR integrates KERV embodied speculative decoding into the FlagScale task launcher.

- Add FlagScale configurations and entrypoints for OpenVLA verifier LoRA fine-tuning, full verifier training, KERV draft-data generation, drafter training, and LIBERO inference.
- Map composed FlagScale configurations to the public KERV and OpenVLA entrypoints without vendoring checkpoints, generated samples, datasets, or machine-specific paths.
- Provide a BF16 lossless inference profile covering KERV kinematic compensation, adaptive acceptance, static-tree verification, CUDA Graph replay, persistent workspaces, and the KERV operator set.
- Add configuration, launcher, path-validation, and command-construction unit tests. The tests use temporary dummy entrypoints and do not download model weights.
- Document installation, verifier/drafter training, inference, checkpoint preparation, and no-weight configuration checks.

Validation completed locally:

- Official `tools/codestyle/pre-commit.sh`: passed.
- KERV unit tests: 11 passed on Python 3.12 and 11 passed on Python 3.10.
- CI-style two-rank `torchrun`: 11 passed on each rank.
- All five public configurations compose and produce valid FlagScale commands without loading weights.
- All 95 configured arguments match the public KERV and OpenVLA entrypoint contracts.

The KERV-specific optimized operators are maintained separately for the FlagOS-Robo integration and are not added to FlagGems in this PR.
