### PR TITLE
add profiler kernel reports

### DIFF
--- a/flagscale/train/megatron/training/profiler_reports.py
+++ b/flagscale/train/megatron/training/profiler_reports.py
@@ -7,20 +7,25 @@ from collections import defaultdict, deque
 from pathlib import Path
 
 DETAIL_FIELDS = [
-    "operator_name", "kernel_name", "variant_index", "mapping_status",
+    "custom_operator", "operator_name", "kernel_name", "variant_index", "mapping_status",
     "input_shapes", "input_dtypes", "candidate_operators",
     "kernel_event_count", "kernel_time_us",
 ]
 SUMMARY_FIELDS = [
-    "operator_name", "kernel_name", "kernel_call_count", "kernel_time_us", "percent",
+    "custom_operator", "operator_name", "kernel_name", "kernel_call_count",
+    "kernel_time_us", "percent",
 ]
-OPERATOR_FIELDS = ["operator_id", "operator_name", "operator_kind", "kernel_name"]
+OPERATOR_FIELDS = [
+    "operator_id", "custom_operator", "operator_name", "operator_kind", "kernel_name",
+]
 
 # These are backend/library identities, not generic tensor operation names. Keep
 # them centralized so support for another communication backend is a data-only change.
 COMMUNICATION_OPERATOR_MARKERS = (
     "record_param_comms", "torch.distributed", "distributed::", "_c10d", "c10d::",
-    "symm_mem::", "custom_ar::", "processgroup", "alltoall_dispatch",
+    "symm_mem::", "custom_ar::", "processgroup", "allreduce", "all_reduce",
+    "allgather", "all_gather", "reducescatter", "reduce_scatter", "alltoall",
+    "all_to_all", "sendrecv", "sequenceparallelregion",
 )
 COMMUNICATION_KERNEL_MARKERS = (
     "nccl", "rccl", "hccl", "oneccl", "custom_all_reduce", "cross_device_reduce",
@@ -33,33 +38,15 @@ NON_COMPUTE_EVENT_NAMES = {
     "Runtime Triggered Module Loading",
 }
 TORCH_COMPILE_PREFIXES = ("triton_", "CompiledFunction")
+FRAMEWORK_OPERATOR_PREFIXES = (
+    "aten::", "autograd::", "torch::", "prims::", "ProfilerStep#",
+    "TorchDynamo ", "Torch-Compiled Region", "CompiledFunction", "triton_",
+)
 
 
 def _json_field(value):
     value = [] if value in (None, "") else value
     return json.dumps(value, separators=(",", ":"), ensure_ascii=False)
-
-
-def _load_trace_metadata(trace_path):
-    """Load CPU-op names and dtype occurrences from a Kineto Chrome trace."""
-    if trace_path is None:
-        return None, {}
-    opener = gzip.open if str(trace_path).endswith(".gz") else open
-    with opener(trace_path, "rt", encoding="utf-8") as trace_file:
-        trace = json.load(trace_file)
-
-    cpu_operator_names = set()
-    input_dtypes = defaultdict(deque)
-    for event in trace.get("traceEvents", ()):
-        if event.get("cat") != "cpu_op" or event.get("ph") != "X":
-            continue
-        name = str(event.get("name", ""))
-        cpu_operator_names.add(name)
-        args = event.get("args", {})
-        if "Input type" in args:
-            key = (name, _json_field(args.get("Input Dims")))
-            input_dtypes[key].append(args["Input type"])
-    return cpu_operator_names, input_dtypes
 
 
 def _is_communication(operator_name, kernel_name):
@@ -68,6 +55,67 @@ def _is_communication(operator_name, kernel_name):
     return any(marker in operator for marker in COMMUNICATION_OPERATOR_MARKERS) or any(
         marker in kernel for marker in COMMUNICATION_KERNEL_MARKERS
     )
+
+
+def _is_custom_operator(name):
+    """Return whether a CPU op is a useful custom-operation boundary."""
+    if not name or name.startswith(FRAMEWORK_OPERATOR_PREFIXES):
+        return False
+    if name.endswith(("Backward0", "Backward1")) or _is_communication(name, ""):
+        return False
+    return (
+        name.startswith("_")
+        or name.endswith(("Function", "FunctionBackward"))
+        or (name[0].isupper() and " " not in name and "::" not in name)
+    )
+
+
+def _load_trace_metadata(trace_path):
+    """Load CPU-op metadata and nearest custom parents from a Kineto trace."""
+    if trace_path is None:
+        return None, {}, {}
+    opener = gzip.open if str(trace_path).endswith(".gz") else open
+    with opener(trace_path, "rt", encoding="utf-8") as trace_file:
+        trace = json.load(trace_file)
+
+    cpu_events = []
+    cpu_operator_names = set()
+    input_dtypes = defaultdict(deque)
+    for event in trace.get("traceEvents", ()):
+        if event.get("cat") != "cpu_op" or event.get("ph") != "X":
+            continue
+        name = str(event.get("name", ""))
+        cpu_operator_names.add(name)
+        cpu_events.append(event)
+        args = event.get("args", {})
+        if "Input type" in args:
+            key = (name, _json_field(args.get("Input Dims")))
+            input_dtypes[key].append(args["Input type"])
+
+    custom_parents = defaultdict(deque)
+    events_by_thread = defaultdict(list)
+    for event in cpu_events:
+        events_by_thread[(event.get("pid"), event.get("tid"))].append(event)
+    for events in events_by_thread.values():
+        events.sort(key=lambda event: (event["ts"], -event.get("dur", 0.0)))
+        stack = []
+        for event in events:
+            start = event["ts"]
+            end = start + event.get("dur", 0.0)
+            while stack and (start >= stack[-1][1] or end > stack[-1][1]):
+                stack.pop()
+            name = str(event.get("name", ""))
+            shapes = _json_field(event.get("args", {}).get("Input Dims"))
+            custom_parent = name if _is_custom_operator(name) else "null"
+            if custom_parent == "null":
+                for parent, _ in reversed(stack):
+                    parent_name = str(parent.get("name", ""))
+                    if _is_custom_operator(parent_name):
+                        custom_parent = parent_name
+                        break
+            custom_parents[(name, shapes)].append(custom_parent)
+            stack.append((event, end))
+    return cpu_operator_names, input_dtypes, custom_parents
 
 
 def _is_non_compute(operator_name, kernel_name, cpu_operator_names):
@@ -88,6 +136,8 @@ def _operator_kind(name):
         return "aten"
     if name.startswith(TORCH_COMPILE_PREFIXES):
         return "torch_compile"
+    if _is_custom_operator(name):
+        return "custom"
     if "::" in name:
         return "custom"
     return "runtime_operator"
@@ -110,7 +160,7 @@ def build_kernel_report_rows(events, trace_path=None):
     """Build detailed and summary rows from ``torch.profiler`` events."""
     variants = defaultdict(lambda: [0, 0.0])
     summaries = defaultdict(lambda: [0, 0.0])
-    cpu_operator_names, trace_dtypes = _load_trace_metadata(trace_path)
+    cpu_operator_names, trace_dtypes, trace_custom_parents = _load_trace_metadata(trace_path)
 
     for event in events:
         if getattr(event, "is_user_annotation", False):
@@ -121,9 +171,12 @@ def build_kernel_report_rows(events, trace_path=None):
             or getattr(event, "input_shapes", None)
         )
         dtype_queue = trace_dtypes.get((operator, shapes))
+        trace_event_dtypes = dtype_queue.popleft() if dtype_queue else None
+        custom_parent_queue = trace_custom_parents.get((operator, shapes))
+        custom_operator = custom_parent_queue.popleft() if custom_parent_queue else "null"
         event_dtypes = getattr(event, "input_dtypes", None)
-        if not event_dtypes and dtype_queue:
-            event_dtypes = dtype_queue.popleft()
+        if not event_dtypes and trace_event_dtypes:
+            event_dtypes = trace_event_dtypes
         kernels = getattr(event, "kernels", None) or ()
         if not kernels:
             continue
@@ -136,20 +189,21 @@ def build_kernel_report_rows(events, trace_path=None):
             ):
                 continue
             duration = _duration_us(kernel)
-            variants[(operator, name, shapes, dtypes)][0] += 1
-            variants[(operator, name, shapes, dtypes)][1] += duration
-            summaries[(operator, name)][0] += 1
-            summaries[(operator, name)][1] += duration
+            variants[(custom_operator, operator, name, shapes, dtypes)][0] += 1
+            variants[(custom_operator, operator, name, shapes, dtypes)][1] += duration
+            summaries[(custom_operator, operator, name)][0] += 1
+            summaries[(custom_operator, operator, name)][1] += duration
 
     grouped = defaultdict(list)
-    for (operator, kernel, shapes, dtypes), (count, duration) in variants.items():
-        grouped[(operator, kernel)].append((shapes, dtypes, count, duration))
+    for (custom, operator, kernel, shapes, dtypes), (count, duration) in variants.items():
+        grouped[(custom, operator, kernel)].append((shapes, dtypes, count, duration))
 
     details = []
-    for (operator, kernel), items in sorted(grouped.items()):
+    for (custom, operator, kernel), items in sorted(grouped.items()):
         items.sort(key=lambda item: (-item[3], item[0], item[1]))
         for index, (shapes, dtypes, count, duration) in enumerate(items, 1):
             details.append({
+                "custom_operator": custom,
                 "operator_name": operator,
                 "kernel_name": kernel,
                 "variant_index": index,
@@ -163,10 +217,11 @@ def build_kernel_report_rows(events, trace_path=None):
 
     total = sum(item[1] for item in summaries.values())
     summary = []
-    for (operator, kernel), (count, duration) in sorted(
+    for (custom, operator, kernel), (count, duration) in sorted(
         summaries.items(), key=lambda item: (-item[1][1], item[0])
     ):
         summary.append({
+            "custom_operator": custom,
             "operator_name": operator,
             "kernel_name": kernel,
             "kernel_call_count": count,
@@ -178,20 +233,26 @@ def build_kernel_report_rows(events, trace_path=None):
 
 def build_operator_rows(summary_rows):
     """List unique operator-to-kernel mappings using stable grouped IDs."""
-    pairs = {(row["operator_name"], row["kernel_name"]) for row in summary_rows}
+    pairs = {
+        (row["custom_operator"], row["operator_name"], row["kernel_name"])
+        for row in summary_rows
+    }
     kind_order = {
         "aten": 0, "custom": 1, "runtime_operator": 2,
         "torch_compile": 3, "unattributed": 4,
     }
     pairs = sorted(
-        pairs, key=lambda pair: (kind_order[_operator_kind(pair[0])], pair[0], pair[1])
+        pairs,
+        key=lambda pair: (kind_order[_operator_kind(pair[1])], pair[0], pair[1], pair[2]),
     )
     operator_ids = {}
     rows = []
-    for operator, kernel in pairs:
-        operator_ids.setdefault(operator, len(operator_ids) + 1)
+    for custom, operator, kernel in pairs:
+        operator_key = (custom, operator)
+        operator_ids.setdefault(operator_key, len(operator_ids) + 1)
         rows.append({
-            "operator_id": operator_ids[operator],
+            "operator_id": operator_ids[operator_key],
+            "custom_operator": custom,
             "operator_name": operator,
             "operator_kind": _operator_kind(operator),
             "kernel_name": kernel,

--- a/flagscale/train/megatron/training/profiler_reports.py
+++ b/flagscale/train/megatron/training/profiler_reports.py
@@ -7,16 +7,16 @@ from collections import defaultdict, deque
 from pathlib import Path
 
 DETAIL_FIELDS = [
-    "custom_operator", "operator_name", "kernel_name", "variant_index", "mapping_status",
+    "custom_operator", "execution_operator", "kernel_name", "variant_index", "mapping_status",
     "input_shapes", "input_dtypes", "candidate_operators",
     "kernel_event_count", "kernel_time_us",
 ]
 SUMMARY_FIELDS = [
-    "custom_operator", "operator_name", "kernel_name", "kernel_call_count",
+    "custom_operator", "execution_operator", "kernel_name", "kernel_call_count",
     "kernel_time_us", "percent",
 ]
 OPERATOR_FIELDS = [
-    "operator_id", "custom_operator", "operator_name", "operator_kind", "kernel_name",
+    "operator_id", "custom_operator", "execution_operator", "operator_kind", "kernel_name",
 ]
 
 # These are backend/library identities, not generic tensor operation names. Keep
@@ -38,6 +38,10 @@ NON_COMPUTE_EVENT_NAMES = {
     "Runtime Triggered Module Loading",
 }
 TORCH_COMPILE_PREFIXES = ("triton_", "CompiledFunction")
+EXECUTION_BACKENDS = {
+    "cuBLASLt", "cuBLAS", "CUTLASS", "TransformerEngine", "Triton",
+    "FlashAttention", "cuDNN", "CUDA",
+}
 FRAMEWORK_OPERATOR_PREFIXES = (
     "aten::", "autograd::", "torch::", "prims::", "ProfilerStep#",
     "TorchDynamo ", "Torch-Compiled Region", "CompiledFunction", "triton_",
@@ -129,9 +133,40 @@ def _is_non_compute(operator_name, kernel_name, cpu_operator_names):
     return any(marker in kernel for marker in NON_COMPUTE_KERNEL_MARKERS)
 
 
+def _kernel_backend(kernel_name):
+    """Infer a stable implementation backend from an observed kernel name."""
+    name = kernel_name.lower()
+    if "nvjet" in name or "cublaslt" in name:
+        return "cuBLASLt"
+    if "cutlass" in name:
+        return "CUTLASS"
+    if "transformer_engine" in name:
+        return "TransformerEngine"
+    if "triton" in name:
+        return "Triton"
+    if any(marker in name for marker in ("flash_attn", "flashattention", "fmha")):
+        return "FlashAttention"
+    if "cudnn" in name:
+        return "cuDNN"
+    if "cublas" in name:
+        return "cuBLAS"
+    return "CUDA"
+
+
+def _execution_operator(custom_operator, operator_name, kernel_name):
+    """Use an observed inner ATen op, otherwise the inferred kernel backend."""
+    if custom_operator == "null":
+        return operator_name
+    if custom_operator != operator_name and operator_name.startswith("aten::"):
+        return operator_name
+    return _kernel_backend(kernel_name)
+
+
 def _operator_kind(name):
     if name == "null":
         return "unattributed"
+    if name in EXECUTION_BACKENDS:
+        return "backend"
     if name.startswith("aten::"):
         return "aten"
     if name.startswith(TORCH_COMPILE_PREFIXES):
@@ -189,22 +224,23 @@ def build_kernel_report_rows(events, trace_path=None):
             ):
                 continue
             duration = _duration_us(kernel)
-            variants[(custom_operator, operator, name, shapes, dtypes)][0] += 1
-            variants[(custom_operator, operator, name, shapes, dtypes)][1] += duration
-            summaries[(custom_operator, operator, name)][0] += 1
-            summaries[(custom_operator, operator, name)][1] += duration
+            execution_operator = _execution_operator(custom_operator, operator, name)
+            variants[(custom_operator, execution_operator, name, shapes, dtypes)][0] += 1
+            variants[(custom_operator, execution_operator, name, shapes, dtypes)][1] += duration
+            summaries[(custom_operator, execution_operator, name)][0] += 1
+            summaries[(custom_operator, execution_operator, name)][1] += duration
 
     grouped = defaultdict(list)
-    for (custom, operator, kernel, shapes, dtypes), (count, duration) in variants.items():
-        grouped[(custom, operator, kernel)].append((shapes, dtypes, count, duration))
+    for (custom, execution, kernel, shapes, dtypes), (count, duration) in variants.items():
+        grouped[(custom, execution, kernel)].append((shapes, dtypes, count, duration))
 
     details = []
-    for (custom, operator, kernel), items in sorted(grouped.items()):
+    for (custom, execution, kernel), items in sorted(grouped.items()):
         items.sort(key=lambda item: (-item[3], item[0], item[1]))
         for index, (shapes, dtypes, count, duration) in enumerate(items, 1):
             details.append({
                 "custom_operator": custom,
-                "operator_name": operator,
+                "execution_operator": execution,
                 "kernel_name": kernel,
                 "variant_index": index,
                 "mapping_status": "operator_shape_matched",
@@ -217,12 +253,12 @@ def build_kernel_report_rows(events, trace_path=None):
 
     total = sum(item[1] for item in summaries.values())
     summary = []
-    for (custom, operator, kernel), (count, duration) in sorted(
+    for (custom, execution, kernel), (count, duration) in sorted(
         summaries.items(), key=lambda item: (-item[1][1], item[0])
     ):
         summary.append({
             "custom_operator": custom,
-            "operator_name": operator,
+            "execution_operator": execution,
             "kernel_name": kernel,
             "kernel_call_count": count,
             "kernel_time_us": _time(duration),
@@ -234,12 +270,12 @@ def build_kernel_report_rows(events, trace_path=None):
 def build_operator_rows(summary_rows):
     """List unique operator-to-kernel mappings using stable grouped IDs."""
     pairs = {
-        (row["custom_operator"], row["operator_name"], row["kernel_name"])
+        (row["custom_operator"], row["execution_operator"], row["kernel_name"])
         for row in summary_rows
     }
     kind_order = {
-        "aten": 0, "custom": 1, "runtime_operator": 2,
-        "torch_compile": 3, "unattributed": 4,
+        "aten": 0, "backend": 1, "custom": 2, "runtime_operator": 3,
+        "torch_compile": 4, "unattributed": 5,
     }
     pairs = sorted(
         pairs,
@@ -253,7 +289,7 @@ def build_operator_rows(summary_rows):
         rows.append({
             "operator_id": operator_ids[operator_key],
             "custom_operator": custom,
-            "operator_name": operator,
+            "execution_operator": operator,
             "operator_kind": _operator_kind(operator),
             "kernel_name": kernel,
         })

--- a/flagscale/train/megatron/training/profiler_reports.py
+++ b/flagscale/train/megatron/training/profiler_reports.py
@@ -1,0 +1,220 @@
+"""Generate operator-to-kernel reports from PyTorch profiler events."""
+
+import csv
+import gzip
+import json
+from collections import defaultdict, deque
+from pathlib import Path
+
+DETAIL_FIELDS = [
+    "operator_name", "kernel_name", "variant_index", "mapping_status",
+    "input_shapes", "input_dtypes", "candidate_operators",
+    "kernel_event_count", "kernel_time_us",
+]
+SUMMARY_FIELDS = [
+    "operator_name", "kernel_name", "kernel_call_count", "kernel_time_us", "percent",
+]
+OPERATOR_FIELDS = ["operator_id", "operator_name", "operator_kind", "kernel_name"]
+
+# These are backend/library identities, not generic tensor operation names. Keep
+# them centralized so support for another communication backend is a data-only change.
+COMMUNICATION_OPERATOR_MARKERS = (
+    "record_param_comms", "torch.distributed", "distributed::", "_c10d", "c10d::",
+    "symm_mem::", "custom_ar::", "processgroup", "alltoall_dispatch",
+)
+COMMUNICATION_KERNEL_MARKERS = (
+    "nccl", "rccl", "hccl", "oneccl", "custom_all_reduce", "cross_device_reduce",
+    "allreduce", "all_reduce", "allgather", "all_gather", "reducescatter",
+    "reduce_scatter", "alltoall", "all_to_all", "sendrecv",
+)
+NON_COMPUTE_KERNEL_MARKERS = ("memcpy", "memset")
+NON_COMPUTE_EVENT_NAMES = {
+    "Lazy Function Loading",
+    "Runtime Triggered Module Loading",
+}
+TORCH_COMPILE_PREFIXES = ("triton_", "CompiledFunction")
+
+
+def _json_field(value):
+    value = [] if value in (None, "") else value
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+
+
+def _load_trace_metadata(trace_path):
+    """Load CPU-op names and dtype occurrences from a Kineto Chrome trace."""
+    if trace_path is None:
+        return None, {}
+    opener = gzip.open if str(trace_path).endswith(".gz") else open
+    with opener(trace_path, "rt", encoding="utf-8") as trace_file:
+        trace = json.load(trace_file)
+
+    cpu_operator_names = set()
+    input_dtypes = defaultdict(deque)
+    for event in trace.get("traceEvents", ()):
+        if event.get("cat") != "cpu_op" or event.get("ph") != "X":
+            continue
+        name = str(event.get("name", ""))
+        cpu_operator_names.add(name)
+        args = event.get("args", {})
+        if "Input type" in args:
+            key = (name, _json_field(args.get("Input Dims")))
+            input_dtypes[key].append(args["Input type"])
+    return cpu_operator_names, input_dtypes
+
+
+def _is_communication(operator_name, kernel_name):
+    operator = operator_name.lower()
+    kernel = kernel_name.lower()
+    return any(marker in operator for marker in COMMUNICATION_OPERATOR_MARKERS) or any(
+        marker in kernel for marker in COMMUNICATION_KERNEL_MARKERS
+    )
+
+
+def _is_non_compute(operator_name, kernel_name, cpu_operator_names):
+    if operator_name in NON_COMPUTE_EVENT_NAMES:
+        return True
+    # Category is more stable than CUDA/HIP API naming. If a trace is available,
+    # reject events that Kineto did not classify as CPU operators.
+    if cpu_operator_names is not None and operator_name not in cpu_operator_names:
+        return True
+    kernel = kernel_name.lower()
+    return any(marker in kernel for marker in NON_COMPUTE_KERNEL_MARKERS)
+
+
+def _operator_kind(name):
+    if name == "null":
+        return "unattributed"
+    if name.startswith("aten::"):
+        return "aten"
+    if name.startswith(TORCH_COMPILE_PREFIXES):
+        return "torch_compile"
+    if "::" in name:
+        return "custom"
+    return "runtime_operator"
+
+
+def _duration_us(kernel):
+    duration = getattr(kernel, "duration", 0.0)
+    return float(duration() if callable(duration) else duration)
+
+
+def _time(value):
+    return f"{value:.3f}".rstrip("0").rstrip(".")
+
+
+def _percent(value):
+    return "<0.001%" if 0 < value < 0.001 else f"{value:.3f}%"
+
+
+def build_kernel_report_rows(events, trace_path=None):
+    """Build detailed and summary rows from ``torch.profiler`` events."""
+    variants = defaultdict(lambda: [0, 0.0])
+    summaries = defaultdict(lambda: [0, 0.0])
+    cpu_operator_names, trace_dtypes = _load_trace_metadata(trace_path)
+
+    for event in events:
+        if getattr(event, "is_user_annotation", False):
+            continue
+        operator = str(getattr(event, "key", None) or getattr(event, "name", "null"))
+        shapes = _json_field(
+            getattr(event, "structured_input_shapes", None)
+            or getattr(event, "input_shapes", None)
+        )
+        dtype_queue = trace_dtypes.get((operator, shapes))
+        event_dtypes = getattr(event, "input_dtypes", None)
+        if not event_dtypes and dtype_queue:
+            event_dtypes = dtype_queue.popleft()
+        kernels = getattr(event, "kernels", None) or ()
+        if not kernels:
+            continue
+        dtypes = _json_field(event_dtypes)
+
+        for kernel in kernels:
+            name = str(getattr(kernel, "name", "null"))
+            if _is_communication(operator, name) or _is_non_compute(
+                operator, name, cpu_operator_names
+            ):
+                continue
+            duration = _duration_us(kernel)
+            variants[(operator, name, shapes, dtypes)][0] += 1
+            variants[(operator, name, shapes, dtypes)][1] += duration
+            summaries[(operator, name)][0] += 1
+            summaries[(operator, name)][1] += duration
+
+    grouped = defaultdict(list)
+    for (operator, kernel, shapes, dtypes), (count, duration) in variants.items():
+        grouped[(operator, kernel)].append((shapes, dtypes, count, duration))
+
+    details = []
+    for (operator, kernel), items in sorted(grouped.items()):
+        items.sort(key=lambda item: (-item[3], item[0], item[1]))
+        for index, (shapes, dtypes, count, duration) in enumerate(items, 1):
+            details.append({
+                "operator_name": operator,
+                "kernel_name": kernel,
+                "variant_index": index,
+                "mapping_status": "operator_shape_matched",
+                "input_shapes": shapes,
+                "input_dtypes": dtypes,
+                "candidate_operators": "null",
+                "kernel_event_count": count,
+                "kernel_time_us": _time(duration),
+            })
+
+    total = sum(item[1] for item in summaries.values())
+    summary = []
+    for (operator, kernel), (count, duration) in sorted(
+        summaries.items(), key=lambda item: (-item[1][1], item[0])
+    ):
+        summary.append({
+            "operator_name": operator,
+            "kernel_name": kernel,
+            "kernel_call_count": count,
+            "kernel_time_us": _time(duration),
+            "percent": _percent(duration / total * 100.0 if total else 0.0),
+        })
+    return details, summary
+
+
+def build_operator_rows(summary_rows):
+    """List unique operator-to-kernel mappings using stable grouped IDs."""
+    pairs = {(row["operator_name"], row["kernel_name"]) for row in summary_rows}
+    kind_order = {
+        "aten": 0, "custom": 1, "runtime_operator": 2,
+        "torch_compile": 3, "unattributed": 4,
+    }
+    pairs = sorted(
+        pairs, key=lambda pair: (kind_order[_operator_kind(pair[0])], pair[0], pair[1])
+    )
+    operator_ids = {}
+    rows = []
+    for operator, kernel in pairs:
+        operator_ids.setdefault(operator, len(operator_ids) + 1)
+        rows.append({
+            "operator_id": operator_ids[operator],
+            "operator_name": operator,
+            "operator_kind": _operator_kind(operator),
+            "kernel_name": kernel,
+        })
+    return rows
+
+
+def _write(path, fields, rows):
+    with Path(path).open("w", newline="", encoding="utf-8-sig") as output:
+        writer = csv.DictWriter(output, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def export_kernel_reports(events, profile_dir, rank, trace_path=None):
+    """Write detailed, summary, and operator-to-kernel reports for one rank."""
+    details, summary = build_kernel_report_rows(events, trace_path)
+    operators = build_operator_rows(summary)
+    profile_dir = Path(profile_dir)
+    details_path = profile_dir / f"rank-{rank}_kernel_details_report.csv"
+    summary_path = profile_dir / f"rank-{rank}_kernel_summary.csv"
+    operator_path = profile_dir / f"rank-{rank}_operator_list.csv"
+    _write(details_path, DETAIL_FIELDS, details)
+    _write(summary_path, SUMMARY_FIELDS, summary)
+    _write(operator_path, OPERATOR_FIELDS, operators)
+    return details_path, summary_path, operator_path

--- a/flagscale/train/megatron/training/profiler_reports.py
+++ b/flagscale/train/megatron/training/profiler_reports.py
@@ -47,6 +47,61 @@ FRAMEWORK_OPERATOR_PREFIXES = (
     "TorchDynamo ", "Torch-Compiled Region", "CompiledFunction", "triton_",
 )
 
+# Profiler-visible autograd classes scanned from TE-FL 21b4b4b1. Keep the full
+# inventory auditable, then exclude infrastructure and metadata-only helpers.
+TE_AUTOGRAD_FUNCTIONS = frozenset({
+    "AttnFuncFL", "FP8EmulationFunc", "_PrepareQKVForFA", "FusedAttnFunc",
+    "AttnFuncWithCPAndKVP2P", "AttnFuncWithCPAndKVAllGather",
+    "AttnFuncWithCPAndQKVOA2A", "FusedAttentionWithScoreModFunc",
+    "ScaledUpperTriangMaskedSoftmax", "ScaledAlignedCausalMaskedSoftmax",
+    "ScaledMaskedSoftmax", "ScaledSoftmax", "PackTensors", "UnpackTensor",
+    "ConvertTHDtoBSHD", "ConvertBSHDtoTHD", "FusedRoPEFunc", "FusedQKVRoPEFunc",
+    "CrossEntropyFunction", "_Fp8Padding", "_Fp8Unpadding", "_GroupedLinear",
+    "_LayerNormLinear", "_LayerNormMLP", "_Linear",
+    "_OperationFuserAutogradFunction", "FusedTopkScoreFunction",
+    "FusedComputeScoresForMoEAuxLoss", "FusedAuxLoss", "_QuantizeFunc",
+    "_FromFloat8Func", "_FromMXFP8Func", "_FromNVFP4Func", "mHCProjectionOp",
+    "mHCScaleFusedOp", "mHCSinkhornOp", "mHCAggregateOp",
+    "mHCExpandCombineOp", "SplitAlongDim", "AllGatherFunc",
+    "GroupCommitFunction", "_CheckpointFunction", "_EpDispatch", "_EpCombine",
+    "Graphed", "_NoopCatFunc", "_IdentityFunc", "_ViewFunc", "_ReshapeFunc",
+    "_GroupedIdentityFunc",
+})
+TE_NON_COMPUTE_AUTOGRAD_FUNCTIONS = frozenset({
+    "AllGatherFunc", "GroupCommitFunction", "_CheckpointFunction", "_EpDispatch",
+    "_EpCombine", "Graphed", "_NoopCatFunc", "_IdentityFunc", "_ViewFunc",
+    "_ReshapeFunc", "_GroupedIdentityFunc",
+})
+TE_CUSTOM_AUTOGRAD_FUNCTIONS = (
+    TE_AUTOGRAD_FUNCTIONS - TE_NON_COMPUTE_AUTOGRAD_FUNCTIONS
+)
+
+# Profiler-visible compute boundaries from the Megatron main revision used by FlagScale.
+MEGATRON_CUSTOM_AUTOGRAD_FUNCTIONS = frozenset({
+    "BiasGeGLUFunction", "GeGLUFunction", "WeightedQuickGeGLUFunction",
+    "WeightedBiasQuickGeGLUFunction", "GeLUFunction", "BiasSwiGLUFunction",
+    "SwiGLUFunction", "WeightedSwiGLUFunction", "_VocabParallelCrossEntropy",
+    "_VocabParallelCrossEntropyChunked", "IndicesToMultihot", "TritonFusedSinkhorn",
+    "CutileSinkhornKnopp", "CutileHAggregate", "CutileProjRms",
+    "CutileProjRmsComputeH", "FusedHAggregate", "FusedHPostBDA",
+    "_FusedMLARoPEInplace", "_FusedMLARoPEKVSplit",
+    "WeightedSquaredReLUFunction", "LinearWithFrozenWeight",
+    "LinearWithGradAccumulationAndAsyncCommunication",
+    "LinearWithGradAccumulationAndAsyncCommunicationKunlunxin",
+    "BatchInvariantTEGemmFn", "BatchInvariantRMSNormFn", "FusedDSAIndexerLoss",
+    "SparseAttnFunc", "FusedIndexerSparseAttnFunc", "_DSASparseAttnFunc",
+    "SinkhornKnopp", "BroadcastTensorFused", "RandomSTE", "RandomSTEShared",
+    "RouterGatingLinearFunction", "RotaryPositionalEmbeddingWithFreqFunction",
+})
+
+CUSTOM_AUTOGRAD_FUNCTIONS = (
+    TE_CUSTOM_AUTOGRAD_FUNCTIONS | MEGATRON_CUSTOM_AUTOGRAD_FUNCTIONS
+)
+CUSTOM_OPERATOR_NAMES = CUSTOM_AUTOGRAD_FUNCTIONS | frozenset(
+    f"{name}Backward" for name in CUSTOM_AUTOGRAD_FUNCTIONS
+)
+CUSTOM_OPERATOR_PREFIXES = ("te_moe::", "tex::")
+
 
 def _json_field(value):
     value = [] if value in (None, "") else value
@@ -62,16 +117,12 @@ def _is_communication(operator_name, kernel_name):
 
 
 def _is_custom_operator(name):
-    """Return whether a CPU op is a useful custom-operation boundary."""
+    """Return whether a CPU op is a known custom compute boundary."""
     if not name or name.startswith(FRAMEWORK_OPERATOR_PREFIXES):
         return False
-    if name.endswith(("Backward0", "Backward1")) or _is_communication(name, ""):
+    if _is_communication(name, ""):
         return False
-    return (
-        name.startswith("_")
-        or name.endswith(("Function", "FunctionBackward"))
-        or (name[0].isupper() and " " not in name and "::" not in name)
-    )
+    return name in CUSTOM_OPERATOR_NAMES or name.startswith(CUSTOM_OPERATOR_PREFIXES)
 
 
 def _load_trace_metadata(trace_path):

--- a/flagscale/train/megatron/training/training.py
+++ b/flagscale/train/megatron/training/training.py
@@ -53,6 +53,7 @@ import torch.distributed
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
 from megatron.core.optimizer_param_scheduler import get_canonical_lr_for_logging
 from .log_handler import CustomHandler
+from .profiler_reports import export_kernel_reports
 
 # Make default logging level INFO, but filter out all log messages not from MCore.
 logging.basicConfig(handlers=[CustomHandler()], level=logging.INFO)
@@ -67,11 +68,6 @@ try:
     has_rl_utils = True
 except ImportError:
     has_rl_utils = False
-
-import csv
-from torch.autograd.profiler import DeviceType
-PROFILER_NCCL_FILTER = {"nccl", "AllReduce", "AllGather", "AllToAll", "Broadcast", "ReduceScatter"}
-PROFILER_MEM_FILTER = {"memcpy", "memset"}
 
 # Canonical list of RL timer names to include in timers_to_log.
 # When the profiling branch is merged, this will be imported from rl_profiling
@@ -3345,61 +3341,20 @@ def train(
             et = torch.profiler.ExecutionTraceObserver().register_callback(f"{et_dir}/rank-{torch.distributed.get_rank()}.json.gz")
         else:
             et = None
+
         def trace_handler(p):
             profile_dir = Path(f"{args.tensorboard_dir}/../torch_profile")
             profile_dir.mkdir(parents=True, exist_ok=True)
             rank = torch.distributed.get_rank()
-            p.export_chrome_trace(f"{profile_dir}/rank-{rank}.json.gz")
-            #  CUDA kernel profiling
-            csv_cuda = f"{profile_dir}/rank-{rank}_cuda_kernel_non_comm.csv"
-            cuda_rows = []
-            for item in p.key_averages():
-                op_name = item.key
-                # collect only non-communication ops with non-zero CUDA time
-                if hasattr(item, 'cuda_time_total') and item.cuda_time_total > 0:
-                    # filter out communication and memory copy ops
-                    is_nccl = any(w.lower() in op_name.lower() for w in PROFILER_NCCL_FILTER)
-                    is_mem = any(w.lower() in op_name.lower() for w in PROFILER_MEM_FILTER)
-                    if is_nccl or is_mem:
-                        continue
-                    avg_cuda = item.cuda_time_total / item.count if item.count > 0 else 0.0
-                    cuda_rows.append({
-                        "kernel_name": op_name,
-                        "count": item.count,
-                        "total_cuda_us": item.cuda_time_total,
-                        "avg_cuda_us": round(avg_cuda, 2),
-                        "self_cuda_us": item.self_cuda_time_total
-                    })
-            cuda_rows.sort(key=lambda x: x["total_cuda_us"], reverse=True)
-            with open(csv_cuda, "w", newline="", encoding="utf-8-sig") as f:
-                field_names = ["kernel_name", "count", "total_cuda_us", "avg_cuda_us", "self_cuda_us"]
-                writer = csv.DictWriter(f, fieldnames=field_names)
-                writer.writeheader()
-                writer.writerows(cuda_rows)
-            print(f"[CUDA] non communication op list is saved to: {csv_cuda}")
-            # PyTorch ATen op profiling
-            csv_torch = f"{profile_dir}/rank-{rank}_torch_aten_op.csv"
-            torch_rows = []
-            for item in p.key_averages():
-                op_name = item.key
-                if item.device_type != DeviceType.CPU:
-                    continue
-                avg_cpu = item.cpu_time_total / item.count if item.count > 0 else 0.0
-                torch_rows.append({
-                    "aten_op_name": op_name,
-                    "count": item.count,
-                    "total_cpu_us": item.cpu_time_total,
-                    "avg_cpu_us": round(avg_cpu, 2),
-                    "self_cpu_us": item.self_cpu_time_total
-                })
+            trace_path = profile_dir / f"rank-{rank}.json.gz"
+            p.export_chrome_trace(str(trace_path))
+            kernel_details_path, kernel_summary_path, operator_list_path = export_kernel_reports(
+                p.events(), profile_dir, rank, trace_path
+            )
+            print(f"[CUDA] kernel details report is saved to: {kernel_details_path}")
+            print(f"[CUDA] kernel summary report is saved to: {kernel_summary_path}")
+            print(f"[CUDA] operator list is saved to: {operator_list_path}")
 
-            torch_rows.sort(key=lambda x: x["total_cpu_us"], reverse=True)
-            with open(csv_torch, "w", newline="", encoding="utf-8-sig") as f:
-                field_names = ["aten_op_name", "count", "total_cpu_us", "avg_cpu_us", "self_cpu_us"]
-                writer = csv.DictWriter(f, fieldnames=field_names)
-                writer.writeheader()
-                writer.writerows(torch_rows)
-            print(f"[Torch Aten] op list is saved to: {csv_torch}")
         prof = torch.profiler.profile(
             schedule=torch.profiler.schedule(
                 wait=max(args.profile_step_start - 1, 0),


### PR DESCRIPTION
### PR Category
<!-- One of [ Train | Inference | Compress | Serve | RL | Core | Hardware | CICD | Tools | Others ] -->
Train
### PR Types
<!-- One of [ User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change| Deprecations | Test Case | Docs | Others ] -->
Others
### PR Description
<!-- Describe what you’ve done -->

## Summary

  This PR improves PyTorch profiler output by generating structured operator-to-CUDA-kernel reports.

  It replaces the previous standalone CUDA kernel and ATen operator CSV files with:

```
  rank-N.json.gz
  rank-N_kernel_details_report.csv
  rank-N_kernel_summary.csv
  rank-N_operator_list.csv
```

  The reports provide:

  - Shape- and dtype-aware operator-to-kernel mappings.
  - Aggregated kernel call counts, execution time, and percentage.
  - A compact operator list with operator classifications.
  - Filtering of communication, memory, CUDA runtime, stream-management, and other non-compute events.

  ## Usage

  Enable profiling under the model section of the FlagScale training configuration:

```yaml
  model:
    profile: true
    use_pytorch_profiler: true
    pytorch_profiler_collect_shapes: true
    profile_step_start: 1
    profile_step_end: 3
    profile_ranks: [0]
```

  Run training through the standard FlagScale entry point:

```shell
  python run.py \
    --config-path ./examples/deepseek_v3/conf/train \
    --config-name engram \
```

  Reports are generated after the profiling window finishes and are written to: `<tensorboard_dir>/../torch_profile/`

  ## Output

  - `rank-N.json.gz`: Raw Chrome trace for Perfetto or other compatible trace viewers.
  - `rank-N_kernel_details_report.csv`: Detailed mappings grouped by operator, CUDA kernel, input shape, and dtype. variant_index distinguishes different input variants of the same operator/kernel pair.
  - `rank-N_kernel_summary.csv`: Aggregated kernel call count, execution time, and percentage for each operator/kernel pair.
  - `rank-N_operator_list.csv`: Unique operator-to-kernel mappings with operator categories such as aten, custom, and torch_compile.