### PR TITLE
[Model] Add KERV optimized runtime operators

### DIFF
--- a/examples/kerv/README.md
+++ b/examples/kerv/README.md
@@ -6,10 +6,10 @@ generation, kinematic feedback, and batched tree verification.
 
 FlagScale provides a native, model-independent KERV control path for batched
 candidate generation, verification-tree construction, relaxed acceptance,
-dynamic threshold adjustment, and Kalman completion. Model definitions,
-weights, datasets, and the optimized KERV operators remain in their public
-upstream projects and are selected through reproducible FlagScale
-configurations.
+dynamic threshold adjustment, and Kalman completion. The KERV-specific
+optimized runtime is bundled under `flagscale/models/kerv/ops`; model
+definitions, weights, and datasets remain in their upstream projects and are
+selected through reproducible FlagScale configurations.
 
 ## Components
 
@@ -20,6 +20,7 @@ configurations.
 | Draft data generation | KERV `training/generate_drafter_data.py` | Frozen-verifier supervision |
 | Drafter training | KERV `training/train_drafter.py` | One-layer speculative drafter |
 | Inference | KERV `run_kerv_libero.py` | LIBERO rollout with KERV runtime optimization |
+| Optimized runtime | FlagScale `flagscale/models/kerv/ops` | KERV operators and model hooks |
 
 ## Installation
 
@@ -119,10 +120,20 @@ flagscale inference kerv -c examples/kerv/conf/inference.yaml
 ```
 
 The default BF16 profile keeps KERV's acceptance rule, Kalman logic, model
-precision, and action definition unchanged. It enables the 14 integrated KERV
-operators from the checked-out `runtime_opt` package, including static-tree
-packing and attention, Verify-Accept control, KV commit, QKV fusion,
-Gate-Up-SwiGLU fusion, and RoPE/KV write.
+precision, and action definition unchanged. The FlagScale entrypoint prepends
+its bundled `KERVRuntimeOptimization` package to `PYTHONPATH`, so the external
+KERV checkout consumes the exact runtime shipped with this integration rather
+than another local copy. The package exposes 18 operator interfaces, selects
+14 for the KERV profile, keeps three experimental interfaces disabled, and
+retains one compatibility interface. Fixed-layout Triton paths are used only
+for shapes that pass the A100 timing gate; the same interfaces remain
+importable without Triton.
+
+The bundled runtime also contains the model hooks used by the default profile:
+packed QKV and Gate-Up projections, in-place SwiGLU, adaptive RoPE, resident KV
+write, per-forward rotary caching, fused LogSoftmax/Top-K, and tree-mask
+construction. See [`flagscale/models/kerv/ops/README.md`](../../flagscale/models/kerv/ops/README.md)
+for the complete operator inventory and benchmark command.
 
 ## Native runtime tests
 

--- a/examples/kerv/benchmark_ops.py
+++ b/examples/kerv/benchmark_ops.py
@@ -1,0 +1,369 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Microbenchmark the public KERV FlagOS operator namespace.
+
+Example:
+    PYTHONPATH=. python examples/kerv/benchmark_ops.py --device cuda
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from pathlib import Path
+
+import torch
+
+from flagscale.models.kerv.ops import (
+    configure_kerv_ops,
+    kerv_action_projection_select,
+    kerv_action_verify_accept,
+    kerv_add_rms_norm,
+    kerv_draft_action_topk,
+    kerv_kv_accept_commit,
+    kerv_kv_commit,
+    kerv_rope_kv_store,
+    kerv_silu_mul,
+    kerv_static_tree_pack,
+    kerv_tree_embed_pack,
+    kerv_value_cache_store,
+    kerv_verify_accept_control,
+    kerv_vision_add_layer_norm,
+    kerv_vision_bias_gelu,
+    static_tree_attention,
+    static_tree_attention_reference,
+)
+
+
+def _time_cuda(call, warmup: int, iterations: int, repeats: int) -> float:
+    for _ in range(warmup):
+        call()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(repeats):
+        begin = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        begin.record()
+        for _ in range(iterations):
+            call()
+        end.record()
+        end.synchronize()
+        samples.append(float(begin.elapsed_time(end)) / iterations)
+    return float(statistics.median(samples))
+
+
+def _time_cpu(call, warmup: int, iterations: int, repeats: int) -> float:
+    for _ in range(warmup):
+        call()
+    samples = []
+    for _ in range(repeats):
+        begin = time.perf_counter()
+        for _ in range(iterations):
+            call()
+        samples.append((time.perf_counter() - begin) * 1000.0 / iterations)
+    return float(statistics.median(samples))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--iterations", type=int, default=200)
+    parser.add_argument("--warmup", type=int, default=100)
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=5,
+        help="independent timing windows; report the median to suppress GPU jitter",
+    )
+    parser.add_argument("--output", default="outputs/kerv_embodied_ops_benchmark.json")
+    parser.add_argument(
+        "--backend",
+        choices=("auto", "native", "triton"),
+        default="auto",
+        help="backend selection; auto keeps unproven tiny paths on ATen",
+    )
+    args = parser.parse_args()
+    device = torch.device(args.device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise SystemExit("CUDA is not available")
+    configure_kerv_ops(
+        enabled=True,
+        include=None,
+        backend=args.backend,
+        record=False,
+        strict=True,
+    )
+    dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
+
+    cases: list[dict[str, object]] = []
+
+    gate = torch.randn(8, 11008, device=device, dtype=dtype)
+    up = torch.randn_like(gate)
+    reference_gate = gate.clone()
+    native_silu = lambda: torch.nn.functional.silu(reference_gate.clone()).mul(up)
+    fused_silu = lambda: kerv_silu_mul(gate.clone(), up)
+    cases.append(_case("kerv_silu_mul", native_silu, fused_silu, device, args))
+
+    hidden = torch.randn(8, 4096, device=device, dtype=dtype)
+    residual = torch.randn_like(hidden)
+    weight = torch.randn(4096, device=device, dtype=dtype)
+    native_rms = lambda: torch.nn.functional.rms_norm(hidden + residual, (4096,), weight, 1e-6)
+    fused_rms = lambda: kerv_add_rms_norm(hidden.clone(), residual, weight, 1e-6)
+    cases.append(_case("kerv_add_rms_norm", native_rms, fused_rms, device, args))
+
+    logits = torch.randn(49, 9, 256, device=device, dtype=dtype)
+    candidates = torch.randint(0, 256, (49, 9), device=device)
+    native_verify = lambda: _native_verify(logits, candidates)
+    fused_verify = lambda: kerv_verify_accept_control(logits, candidates, 0.0, 0)
+    cases.append(_case("kerv_verify_accept_control", native_verify, fused_verify, device, args))
+
+    draft = torch.randint(0, 32000, (1, 320), device=device)
+    kept = torch.tensor([0, 3, 7, 15, 28, 42, 55, 63], device=device)
+    native_pack = lambda: torch.cat(
+        (draft.index_select(1, kept), draft[:, :1].expand(-1, 256 - kept.numel())), dim=1
+    )
+    fused_pack = lambda: kerv_static_tree_pack(draft, kept, 256)
+    cases.append(_case("kerv_static_tree_pack", native_pack, fused_pack, device, args))
+
+    hidden = torch.randn(8, 4096, device=device, dtype=dtype)
+    action_weight = torch.randn(256, 4096, device=device, dtype=dtype)
+    native_action = lambda: torch.nn.functional.linear(hidden, action_weight).argmax(-1) + 31744
+    fused_action = lambda: kerv_action_projection_select(hidden, action_weight, 31744)
+    cases.append(_case("kerv_action_projection_select", native_action, fused_action, device, args))
+
+    # Phase-two action path: keep the verifier control outputs integer-exact.
+    verify_hidden = torch.randn(49 * 9, 4096, device=device, dtype=dtype)
+    verify_weight = torch.randn(256, 4096, device=device, dtype=dtype)
+    verify_candidates = torch.randint(0, 256, (49, 9), device=device)
+    native_action_verify = lambda: _native_action_verify(
+        verify_hidden, verify_weight, verify_candidates
+    )
+    fused_action_verify = lambda: kerv_action_verify_accept(
+        verify_hidden, verify_weight, verify_candidates, 0.0, 0
+    )
+    cases.append(
+        _case("kerv_action_verify_accept", native_action_verify, fused_action_verify, device, args)
+    )
+
+    draft_hidden = torch.randn(8, 1152, device=device, dtype=dtype)
+    draft_weight = torch.randn(256, 1152, device=device, dtype=dtype)
+    native_draft_topk = lambda: _native_draft_topk(draft_hidden, draft_weight, 8, 0)
+    fused_draft_topk = lambda: kerv_draft_action_topk(draft_hidden, draft_weight, 0, 8)
+    cases.append(_case("kerv_draft_action_topk", native_draft_topk, fused_draft_topk, device, args))
+
+    # Embedding pack uses a compact benchmark vocabulary while retaining the
+    # real KERV target width and padding behavior.
+    tree_source = torch.randint(0, 2048, (1, 320), device=device)
+    tree_kept = torch.tensor([0, 3, 7, 15, 28, 42, 55, 63], device=device)
+    tree_embedding = torch.randn(2048, 1152, device=device, dtype=dtype)
+    native_tree_embed = lambda: _native_tree_embed(tree_source, tree_kept, tree_embedding, 256)
+    fused_tree_embed = lambda: kerv_tree_embed_pack(tree_source, tree_kept, tree_embedding, 256)
+    cases.append(_case("kerv_tree_embed_pack", native_tree_embed, fused_tree_embed, device, args))
+
+    query = torch.randn(1, 4, 8, 128, device=device, dtype=dtype)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    cos = torch.randn(1, 8, 128, device=device, dtype=dtype)
+    sin = torch.randn_like(cos)
+    empty_positions = torch.empty(0, dtype=torch.long, device=device)
+    native_rope = lambda: _native_rope_store(
+        query, key, value, cos, sin, empty_positions, 16, device, dtype
+    )
+    fused_rope = lambda: _fused_rope_store(query, key, value, cos, sin, empty_positions, 16)
+    cases.append(_case("kerv_rope_kv_store", native_rope, fused_rope, device, args))
+
+    source = torch.randn(1, 4, 8, 128, device=device, dtype=dtype)
+    native_value_cache = lambda: _native_cache_store(
+        torch.zeros(1, 4, 64, 128, device=device, dtype=dtype), source, 16
+    )
+    fused_value_cache = lambda: kerv_value_cache_store(
+        torch.zeros(1, 4, 64, 128, device=device, dtype=dtype), source, 16
+    )
+    cases.append(
+        _case("kerv_value_cache_store", native_value_cache, fused_value_cache, device, args)
+    )
+
+    native_commit = lambda: _native_cache_store(
+        torch.zeros(1, 4, 64, 128, device=device, dtype=dtype), source, 16
+    )
+    fused_commit = lambda: kerv_kv_commit(
+        torch.zeros(1, 4, 64, 128, device=device, dtype=dtype), source, 16
+    )
+    cases.append(_case("kerv_kv_commit", native_commit, fused_commit, device, args))
+
+    commit_storage = torch.zeros(2, 2, 1, 4, 64, 128, device=device, dtype=dtype)
+    commit_indices = torch.tensor([9, 4, 6, 2], device=device)
+    commit_storage[..., 24 + commit_indices, :] = torch.randn(
+        2, 2, 1, 4, 4, 128, device=device, dtype=dtype
+    )
+    native_accept_commit = lambda: _native_accept_commit(commit_storage.clone(), commit_indices, 24)
+    fused_accept_commit = lambda: kerv_kv_accept_commit(commit_storage.clone(), commit_indices, 24)
+    cases.append(
+        _case("kerv_kv_accept_commit", native_accept_commit, fused_accept_commit, device, args)
+    )
+
+    vision_hidden = torch.randn(102, 1024, device=device, dtype=dtype)
+    vision_residual = torch.randn_like(vision_hidden)
+    vision_weight = torch.randn(1024, device=device, dtype=dtype)
+    vision_bias = torch.randn(1024, device=device, dtype=dtype)
+    native_vision_norm = lambda: torch.nn.functional.layer_norm(
+        vision_hidden + vision_residual, (1024,), vision_weight, vision_bias, 1e-5
+    )
+    fused_vision_norm = lambda: kerv_vision_add_layer_norm(
+        vision_hidden, vision_residual, vision_weight, vision_bias, 1e-5
+    )
+    cases.append(
+        _case("kerv_vision_add_layer_norm", native_vision_norm, fused_vision_norm, device, args)
+    )
+    native_vision_gelu = lambda: torch.nn.functional.gelu(
+        vision_hidden + vision_bias, approximate="none"
+    )
+    fused_vision_gelu = lambda: kerv_vision_bias_gelu(vision_hidden, vision_bias)
+    cases.append(
+        _case("kerv_vision_bias_gelu", native_vision_gelu, fused_vision_gelu, device, args)
+    )
+
+    query = torch.randn(1, 4, 64, 128, device=device, dtype=dtype)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    ancestors = torch.full((64, 5), -1, device=device, dtype=torch.long)
+    ancestors[32:, 0] = torch.arange(32, 64, device=device)
+    ancestors[33:, 1] = 32 + (torch.arange(33, 64, device=device) - 33) // 2
+    native_attention = lambda: static_tree_attention_reference(query, key, value, ancestors, 32)
+    fused_attention = lambda: static_tree_attention(query, key, value, ancestors, 32)
+    cases.append(
+        _case("kerv_static_tree_attention", native_attention, fused_attention, device, args)
+    )
+
+    result = {
+        "torch": torch.__version__,
+        "device": str(device),
+        "dtype": str(dtype),
+        "cases": cases,
+    }
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(json.dumps(result, indent=2))
+
+
+def _native_verify(logits, candidates):
+    predicted = logits[:, :-1].argmax(-1)
+    accepted = torch.cumprod((candidates[:, 1:] == predicted).int(), dim=1).sum(dim=1)
+    best = accepted.argmax()
+    return best, accepted[best]
+
+
+def _native_action_verify(hidden, weight, candidates):
+    logits = torch.nn.functional.linear(hidden, weight).reshape(*candidates.shape, weight.shape[0])
+    predicted = logits.argmax(-1)
+    matches = predicted[:, :-1] == candidates[:, 1:]
+    accepted = torch.cumprod(matches.to(torch.int32), dim=1).sum(-1)
+    best = accepted.argmax()
+    length = accepted[best]
+    next_token = predicted[best, length.clamp_max(predicted.shape[1] - 1)]
+    return best, length, next_token
+
+
+def _native_draft_topk(hidden, weight, k, offset):
+    logits = torch.nn.functional.linear(hidden, weight)
+    values, indices = torch.sort(
+        torch.nn.functional.log_softmax(logits.float(), dim=-1),
+        dim=-1,
+        descending=True,
+        stable=True,
+    )
+    return values[:, :k].to(logits.dtype), indices[:, :k].long() + offset
+
+
+def _native_tree_embed(tokens, kept, embedding, target_nodes):
+    selected = tokens.index_select(1, kept)
+    selected = torch.cat(
+        (selected, selected[:, :1].expand(-1, target_nodes - selected.shape[1])), dim=1
+    )
+    return torch.nn.functional.embedding(selected, embedding)
+
+
+def _native_rope_store(query, key, value, cos, sin, positions, write_start, device, dtype):
+    del positions, device, dtype
+    half = query.shape[-1] // 2
+    rotate = lambda x: torch.cat((-x[..., half:], x[..., :half]), dim=-1)
+    q_out = query * cos.unsqueeze(1) + rotate(query) * sin.unsqueeze(1)
+    k_out = key * cos.unsqueeze(1) + rotate(key) * sin.unsqueeze(1)
+    key_cache = torch.zeros(
+        1, key.shape[1], 64, key.shape[-1], device=query.device, dtype=query.dtype
+    )
+    value_cache = torch.zeros_like(key_cache)
+    key_cache[..., write_start : write_start + key.shape[2], :].copy_(k_out)
+    value_cache[..., write_start : write_start + value.shape[2], :].copy_(value)
+    return q_out, key_cache, value_cache
+
+
+def _fused_rope_store(query, key, value, cos, sin, positions, write_start):
+    key_cache = torch.zeros(
+        1, key.shape[1], 64, key.shape[-1], device=query.device, dtype=query.dtype
+    )
+    value_cache = torch.zeros_like(key_cache)
+    q_out = kerv_rope_kv_store(
+        query, key, value, cos, sin, positions, key_cache, value_cache, write_start
+    )
+    return q_out, key_cache, value_cache
+
+
+def _native_accept_commit(storage, indices, previous_length):
+    source = storage[..., previous_length + indices, :].clone()
+    storage[..., previous_length : previous_length + indices.numel(), :].copy_(source)
+    return storage
+
+
+def _native_cache_store(destination, source, write_start):
+    destination[..., write_start : write_start + source.shape[-2], :].copy_(source)
+    return destination
+
+
+def _case(name, native, fused, device, args):
+    if device.type == "cuda":
+        native_ms = _time_cuda(native, args.warmup, args.iterations, args.repeats)
+        fused_ms = _time_cuda(fused, args.warmup, args.iterations, args.repeats)
+    else:
+        native_ms = _time_cpu(native, args.warmup, args.iterations, args.repeats)
+        fused_ms = _time_cpu(fused, args.warmup, args.iterations, args.repeats)
+    native_result = native()
+    fused_result = fused()
+    if isinstance(native_result, tuple):
+        checks = []
+        for left, right in zip(native_result, fused_result):
+            if left.dtype in (torch.int32, torch.int64, torch.long, torch.bool):
+                checks.append(torch.equal(left, right))
+            else:
+                checks.append(torch.allclose(left, right, rtol=2e-2, atol=2e-2))
+        exact = all(checks)
+    elif native_result.dtype in (torch.int32, torch.int64, torch.long, torch.bool):
+        exact = torch.equal(native_result, fused_result)
+    else:
+        exact = bool(torch.allclose(native_result, fused_result, rtol=2e-2, atol=2e-2))
+    return {
+        "operator": name,
+        "native_ms": native_ms,
+        "fused_ms": fused_ms,
+        "speedup": native_ms / fused_ms if fused_ms else None,
+        "correct": exact,
+    }
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/kerv/conf/inference/kerv.yaml
+++ b/examples/kerv/conf/inference/kerv.yaml
@@ -7,12 +7,13 @@ kerv:
   work_dir: .
   python_paths:
     - ${oc.env:KERV_SOURCE_ROOT,./KERV}/openvla
-    - ${oc.env:KERV_SOURCE_ROOT,./KERV}/runtime_opt
   dependencies:
     - torch
     - transformers
     - draccus
     - libero
+    # KERVRuntimeOptimization is bundled under flagscale/models/kerv/ops and
+    # is prepended to PYTHONPATH by the FlagScale KERV entrypoint.
     - KERVRuntimeOptimization
   env:
     LIBERO_CONFIG_PATH: ${oc.env:LIBERO_CONFIG_PATH,./.libero}

--- a/flagscale/models/kerv/entrypoint.py
+++ b/flagscale/models/kerv/entrypoint.py
@@ -72,7 +72,7 @@ def load_kerv_task_config(config_path: str | Path) -> DictConfig:
 def _render_value(value: Any) -> str:
     if isinstance(value, bool):
         return "True" if value else "False"
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes):
         return ",".join(str(item) for item in value)
     return str(value)
 
@@ -131,10 +131,13 @@ def _resolve_script(root: Path, target: str) -> Path | None:
 
 
 def _python_paths(kerv: Mapping[str, Any], root: Path) -> list[str]:
+    bundled_runtime = str((Path(__file__).resolve().parent / "ops").resolve())
     configured = [
         str(Path(str(value)).expanduser().resolve()) for value in kerv.get("python_paths", [])
     ]
-    return list(dict.fromkeys((str(root), *configured)))
+    # Keep the bundled runtime first so the KERV source checkout consumes the
+    # exact operator implementation shipped with this FlagScale integration.
+    return list(dict.fromkeys((bundled_runtime, str(root), *configured)))
 
 
 @contextmanager
@@ -172,13 +175,23 @@ def _check_dependencies(kerv: Mapping[str, Any]) -> None:
     if isinstance(dependencies, str):
         dependencies = [dependencies]
     for module_name in dependencies:
+        module_name = str(module_name)
         try:
-            importlib.import_module(str(module_name))
+            module = importlib.import_module(module_name)
         except ModuleNotFoundError as error:
             raise KERVEntrypointError(
                 f"KERV stage '{kerv.get('stage')}' requires Python module "
                 f"'{module_name}', but it is not installed in {sys.executable}."
             ) from error
+        if module_name == "KERVRuntimeOptimization":
+            module_file = Path(str(getattr(module, "__file__", ""))).resolve()
+            bundled_runtime = (Path(__file__).resolve().parent / "ops").resolve()
+            if not module_file.is_relative_to(bundled_runtime):
+                raise KERVEntrypointError(
+                    "KERVRuntimeOptimization was imported from an unexpected location: "
+                    f"{module_file}. Start a fresh FlagScale worker so the bundled KERV "
+                    "runtime can be loaded before any external copy."
+                )
 
 
 def _load_script_module(script: Path) -> ModuleType:

--- a/flagscale/models/kerv/launcher.py
+++ b/flagscale/models/kerv/launcher.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any
 
 from .entrypoint import (
     KERVEntrypointError,
+    _python_paths,
     build_inprocess_argv,
     load_kerv_task_config,
     run_kerv_entrypoint,
@@ -78,9 +79,7 @@ def build_kerv_command(kerv: Mapping[str, Any]) -> tuple[list[str], Path, dict[s
     command = [sys.executable, str(script), *build_inprocess_argv(kerv)]
     work_dir = Path(str(kerv.get("work_dir") or root)).expanduser().resolve()
     environment = os.environ.copy()
-    python_paths = [str(root)] + [
-        str(Path(str(value)).expanduser().resolve()) for value in kerv.get("python_paths", [])
-    ]
+    python_paths = _python_paths(kerv, root)
     environment["PYTHONPATH"] = os.pathsep.join(
         value for value in (*python_paths, environment.get("PYTHONPATH", "")) if value
     )

--- a/flagscale/models/kerv/ops/KERVRuntimeOptimization/__init__.py
+++ b/flagscale/models/kerv/ops/KERVRuntimeOptimization/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""On-device runtime optimizations for KERV."""
+
+__version__ = "0.1.0"

--- a/flagscale/models/kerv/ops/KERVRuntimeOptimization/adaptive_linear_fusion.py
+++ b/flagscale/models/kerv/ops/KERVRuntimeOptimization/adaptive_linear_fusion.py
@@ -1,0 +1,673 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Inference-only grouped Linear fusion for small-batch transformer models."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+from types import MethodType
+from typing import TYPE_CHECKING, Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+_RECORD_PATH: Path | None = None
+_RECORD_ONCE = True
+_RECORDED: set[tuple[object, ...]] = set()
+
+
+def configure_linear_fusion_recording(
+    path: str | None,
+    record: bool,
+    once: bool = True,
+) -> None:
+    global _RECORD_PATH, _RECORD_ONCE
+    _RECORD_PATH = Path(path) if record and path else None
+    _RECORD_ONCE = bool(once)
+    _RECORDED.clear()
+    if _RECORD_PATH is not None:
+        _RECORD_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _RECORD_PATH.touch(exist_ok=True)
+
+
+def _parse_rows(values: str | None) -> tuple[int, ...]:
+    values = "" if values is None else str(values).strip()
+    if values.lower() in ("", "none", "null"):
+        return ()
+    rows = tuple(sorted(set(int(value.strip()) for value in values.split(",") if value.strip())))
+    if any(value <= 0 for value in rows):
+        raise ValueError(f"fusion row counts must be positive: {rows}")
+    return rows
+
+
+def _record_hit(
+    kind: str,
+    value: torch.Tensor,
+    output_sizes: Sequence[int],
+    implementation: str = "flagos_grouped_cublas_linear",
+) -> None:
+    if _RECORD_PATH is None:
+        return
+    key = (kind, tuple(value.shape), tuple(output_sizes), str(value.dtype))
+    if _RECORD_ONCE and key in _RECORDED:
+        return
+    _RECORDED.add(key)
+    record = {
+        "operator": kind,
+        "implementation": implementation,
+        "shape": list(value.shape),
+        "dtype": str(value.dtype).removeprefix("torch."),
+        "output_sizes": list(output_sizes),
+    }
+    with _RECORD_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record) + "\n")
+
+
+class _LinearGroup:
+    """Own one packed weight and serve sequential slices from one GEMM."""
+
+    def __init__(
+        self,
+        linears: Sequence[nn.Linear],
+        kind: str,
+        fused_rows: Sequence[int],
+    ):
+        if len(linears) < 2:
+            raise ValueError("a fused Linear group requires at least two projections")
+        first = linears[0]
+        if any(layer.in_features != first.in_features for layer in linears):
+            raise ValueError("all fused Linear projections must share in_features")
+        if any(layer.weight.device != first.weight.device for layer in linears):
+            raise ValueError("all fused Linear projections must share a device")
+        if any(layer.weight.dtype != first.weight.dtype for layer in linears):
+            raise ValueError("all fused Linear projections must share a dtype")
+
+        self.kind = kind
+        self.in_features = first.in_features
+        self.fused_rows = frozenset(int(value) for value in fused_rows)
+        self.output_sizes = tuple(layer.out_features for layer in linears)
+        self.offsets = tuple(
+            sum(self.output_sizes[:index]) for index in range(len(self.output_sizes))
+        )
+        self.weight = torch.cat([layer.weight.detach() for layer in linears], dim=0).contiguous()
+        if any(layer.bias is not None for layer in linears):
+            biases = [
+                layer.bias.detach()
+                if layer.bias is not None
+                else torch.zeros(
+                    layer.out_features,
+                    device=layer.weight.device,
+                    dtype=layer.weight.dtype,
+                )
+                for layer in linears
+            ]
+            self.bias = torch.cat(biases, dim=0).contiguous()
+        else:
+            self.bias = None
+        self._cached_input: torch.Tensor | None = None
+        self._cached_outputs: tuple[torch.Tensor, ...] | None = None
+        self._cached_fused = False
+
+    @property
+    def packed_bytes(self) -> int:
+        total = self.weight.numel() * self.weight.element_size()
+        if self.bias is not None:
+            total += self.bias.numel() * self.bias.element_size()
+        return total
+
+    def weight_slice(self, index: int) -> torch.Tensor:
+        start = self.offsets[index]
+        return self.weight.narrow(0, start, self.output_sizes[index])
+
+    def bias_slice(self, index: int) -> torch.Tensor | None:
+        if self.bias is None:
+            return None
+        start = self.offsets[index]
+        return self.bias.narrow(0, start, self.output_sizes[index])
+
+    def forward(self, index: int, value: torch.Tensor) -> torch.Tensor:
+        if index == 0:
+            self._cached_input = value
+            rows = value.numel() // value.shape[-1]
+            self._cached_fused = rows in self.fused_rows
+            if self._cached_fused:
+                _record_hit(self.kind, value, self.output_sizes)
+                combined = F.linear(value, self.weight, self.bias)
+                self._cached_outputs = torch.split(combined, self.output_sizes, dim=-1)
+            else:
+                self._cached_outputs = None
+        elif self._cached_input is not value:
+            raise RuntimeError(
+                f"{self.kind} projections must execute sequentially on the same tensor"
+            )
+        if self._cached_fused:
+            if self._cached_outputs is None:
+                raise RuntimeError(f"{self.kind} fused output cache is missing")
+            result = self._cached_outputs[index]
+        else:
+            result = F.linear(value, self.weight_slice(index), self.bias_slice(index))
+        if index == len(self.output_sizes) - 1:
+            self._cached_input = None
+            self._cached_outputs = None
+            self._cached_fused = False
+        return result
+
+
+class FusedLinearSlice(nn.Module):
+    """Drop-in ``nn.Linear`` view backed by a shared packed projection."""
+
+    def __init__(self, group: _LinearGroup, index: int):
+        super().__init__()
+        object.__setattr__(self, "_group", group)
+        self.index = int(index)
+        self.in_features = group.in_features
+        self.out_features = group.output_sizes[index]
+
+    @property
+    def weight(self) -> torch.Tensor:
+        return self._group.weight_slice(self.index)
+
+    @property
+    def bias(self) -> torch.Tensor | None:
+        return self._group.bias_slice(self.index)
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        return self._group.forward(self.index, value)
+
+
+def _compatible_linears(values: Iterable[object]) -> bool:
+    linears = list(values)
+    return bool(linears) and all(
+        isinstance(value, nn.Linear)
+        and not isinstance(value, FusedLinearSlice)
+        and value.weight.device.type == "cuda"
+        and not value.weight.is_meta
+        for value in linears
+    )
+
+
+def _compatible_swiglu_module(
+    module: nn.Module,
+    input_sizes: Sequence[int],
+) -> bool:
+    required = ("gate_proj", "up_proj", "down_proj", "act_fn")
+    if not all(hasattr(module, name) for name in required):
+        return False
+    gate = module.gate_proj
+    up = module.up_proj
+    down = module.down_proj
+    if not all(isinstance(value, nn.Linear | FusedLinearSlice) for value in (gate, up)):
+        return False
+    if not isinstance(down, nn.Linear):
+        return False
+    if gate.in_features != up.in_features or gate.out_features != up.out_features:
+        return False
+    if input_sizes and gate.in_features not in input_sizes:
+        return False
+    config = getattr(module, "config", None)
+    if config is not None and int(getattr(config, "pretraining_tp", 1)) != 1:
+        return False
+    activation_name = type(module.act_fn).__name__.lower()
+    return "silu" in activation_name or "swish" in activation_name
+
+
+def _patch_swiglu(
+    module: nn.Module,
+    fused_rows: Sequence[int],
+    backend: str,
+) -> None:
+    allowed_rows = frozenset(int(value) for value in fused_rows)
+    if backend == "flag_gems_out":
+        import flag_gems
+
+        def silu_and_mul(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+            return flag_gems.silu_and_mul_out(gate, up, gate)
+
+        implementation = "flag_gems_silu_and_mul_out"
+    elif backend == "flag_gems":
+        import flag_gems
+
+        silu_and_mul = flag_gems.silu_and_mul
+        implementation = "flag_gems_silu_and_mul"
+    elif backend == "native_inplace":
+
+        def silu_and_mul(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+            return F.silu(gate, inplace=True).mul_(up)
+
+        implementation = "flagos_inplace_silu_and_mul"
+    elif backend == "flagos_kerv":
+        from KERVRuntimeOptimization.embodied_ops import kerv_silu_mul
+
+        silu_and_mul = kerv_silu_mul
+        implementation = "flagos_embodied_kerv_silu_mul"
+    else:
+        raise ValueError(f"unsupported SwiGLU backend: {backend}")
+
+    def flagos_mlp_forward(self, value: torch.Tensor) -> torch.Tensor:
+        gate = self.gate_proj(value)
+        up = self.up_proj(value)
+        rows = gate.numel() // gate.shape[-1]
+        if rows in allowed_rows:
+            _record_hit(
+                "silu_and_mul",
+                gate,
+                (gate.shape[-1],),
+                implementation=implementation,
+            )
+            intermediate = silu_and_mul(gate, up)
+        else:
+            intermediate = self.act_fn(gate) * up
+        return self.down_proj(intermediate)
+
+    module.forward = MethodType(flagos_mlp_forward, module)
+
+
+def _compatible_add_rms_norm_decoder(
+    module: nn.Module,
+    input_sizes: Sequence[int],
+) -> bool:
+    required = (
+        "input_layernorm",
+        "post_attention_layernorm",
+        "self_attn",
+        "mlp",
+    )
+    if not all(hasattr(module, name) for name in required):
+        return False
+    norm = module.post_attention_layernorm
+    weight = getattr(norm, "weight", None)
+    if not isinstance(weight, torch.Tensor):
+        return False
+    if weight.device.type != "cuda" or weight.is_meta or weight.ndim != 1:
+        return False
+    return not input_sizes or weight.numel() in input_sizes
+
+
+def _patch_fused_add_rms_norm(
+    module: nn.Module,
+    fused_rows: Sequence[int],
+    fused_operator,
+    implementation: str,
+) -> None:
+    """Fuse attention residual-add with the following RMSNorm."""
+    allowed_rows = frozenset(int(value) for value in fused_rows)
+    attention_signature = inspect.signature(module.self_attn.forward)
+    attention_parameters = attention_signature.parameters
+    accepts_extra_kwargs = any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in attention_parameters.values()
+    )
+
+    def flagos_decoder_forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask=None,
+        position_ids=None,
+        past_key_value=None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        cache_position=None,
+        position_embeddings=None,
+        **kwargs,
+    ):
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        call_arguments = {
+            "hidden_states": hidden_states,
+            "attention_mask": attention_mask,
+            "position_ids": position_ids,
+            "past_key_value": past_key_value,
+            "output_attentions": output_attentions,
+            "use_cache": use_cache,
+            "cache_position": cache_position,
+            "position_embeddings": position_embeddings,
+        }
+        if accepts_extra_kwargs:
+            call_arguments.update(kwargs)
+        else:
+            call_arguments = {
+                name: value
+                for name, value in call_arguments.items()
+                if name in attention_parameters
+            }
+        attention_outputs = self.self_attn(**call_arguments)
+        hidden_states, self_attn_weights, present_key_value = attention_outputs
+
+        rows = hidden_states.numel() // hidden_states.shape[-1]
+        if rows in allowed_rows:
+            norm = self.post_attention_layernorm
+            weight = norm.weight
+            epsilon = float(getattr(norm, "variance_epsilon", getattr(norm, "eps", 1e-6)))
+            _record_hit(
+                "fused_add_rms_norm",
+                hidden_states,
+                (weight.numel(),),
+                implementation=implementation,
+            )
+            if implementation == "flagos_native_inplace_add_rms_norm":
+                torch.add(residual, hidden_states, out=hidden_states)
+                residual = hidden_states
+                hidden_states = self.post_attention_layernorm(hidden_states)
+            else:
+                hidden_states, residual = fused_operator(
+                    hidden_states,
+                    residual,
+                    (weight.numel(),),
+                    weight,
+                    epsilon,
+                )
+        else:
+            hidden_states = residual + hidden_states
+            residual = hidden_states
+            hidden_states = self.post_attention_layernorm(hidden_states)
+
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        outputs = (hidden_states,)
+        if output_attentions:
+            outputs += (self_attn_weights,)
+        if use_cache:
+            outputs += (present_key_value,)
+        return outputs
+
+    module.forward = MethodType(flagos_decoder_forward, module)
+
+
+def _replace_group(
+    module: nn.Module,
+    names: Sequence[str],
+    kind: str,
+    fused_rows: Sequence[int],
+) -> _LinearGroup:
+    linears = [getattr(module, name) for name in names]
+    group = _LinearGroup(linears, kind, fused_rows)
+    for index, name in enumerate(names):
+        setattr(module, name, FusedLinearSlice(group, index))
+    return group
+
+
+def fuse_transformer_linears(
+    model: nn.Module,
+    qkv_rows: Sequence[int] = (),
+    gate_up_rows: Sequence[int] = (),
+    qkv_input_sizes: Sequence[int] = (),
+    gate_up_input_sizes: Sequence[int] = (),
+    swiglu_rows: Sequence[int] = (),
+    swiglu_input_sizes: Sequence[int] = (),
+    swiglu_backend: str = "native_inplace",
+    add_rms_norm_rows: Sequence[int] = (),
+    add_rms_norm_input_sizes: Sequence[int] = (),
+    add_rms_norm_backend: str = "native_inplace",
+) -> dict[str, object]:
+    """Replace standard sequential projections after final device placement.
+
+    Only explicitly allowlisted flattened row counts use the packed GEMM. Other
+    shapes execute the original per-projection calculation through weight views.
+    This keeps dynamic decoding paths correct and avoids regressions on shapes
+    for which the grouped cuBLAS call is slower.
+    """
+    qkv_rows = tuple(sorted(set(int(value) for value in qkv_rows)))
+    gate_up_rows = tuple(sorted(set(int(value) for value in gate_up_rows)))
+    qkv_input_sizes = tuple(sorted(set(int(value) for value in qkv_input_sizes)))
+    gate_up_input_sizes = tuple(sorted(set(int(value) for value in gate_up_input_sizes)))
+    swiglu_rows = tuple(sorted(set(int(value) for value in swiglu_rows)))
+    swiglu_input_sizes = tuple(sorted(set(int(value) for value in swiglu_input_sizes)))
+    add_rms_norm_rows = tuple(sorted(set(int(value) for value in add_rms_norm_rows)))
+    add_rms_norm_input_sizes = tuple(sorted(set(int(value) for value in add_rms_norm_input_sizes)))
+    candidates = [
+        (name, module)
+        for name, module in model.named_modules()
+        if not isinstance(module, FusedLinearSlice)
+        and (
+            all(hasattr(module, item) for item in ("q_proj", "k_proj", "v_proj"))
+            or all(hasattr(module, item) for item in ("gate_proj", "up_proj"))
+        )
+    ]
+    groups: list[_LinearGroup] = []
+    qkv_modules: list[str] = []
+    gate_up_modules: list[str] = []
+    swiglu_modules: list[str] = []
+    add_rms_norm_modules: list[str] = []
+    for name, module in candidates:
+        if qkv_rows and all(hasattr(module, item) for item in ("q_proj", "k_proj", "v_proj")):
+            values = [module.q_proj, module.k_proj, module.v_proj]
+            if _compatible_linears(values) and (
+                not qkv_input_sizes or values[0].in_features in qkv_input_sizes
+            ):
+                groups.append(
+                    _replace_group(
+                        module,
+                        ("q_proj", "k_proj", "v_proj"),
+                        "qkv_linear",
+                        qkv_rows,
+                    )
+                )
+                qkv_modules.append(name)
+        if gate_up_rows and all(hasattr(module, item) for item in ("gate_proj", "up_proj")):
+            values = [module.gate_proj, module.up_proj]
+            if _compatible_linears(values) and (
+                not gate_up_input_sizes or values[0].in_features in gate_up_input_sizes
+            ):
+                groups.append(
+                    _replace_group(
+                        module,
+                        ("gate_proj", "up_proj"),
+                        "gate_up_linear",
+                        gate_up_rows,
+                    )
+                )
+                gate_up_modules.append(name)
+        if swiglu_rows and _compatible_swiglu_module(module, swiglu_input_sizes):
+            _patch_swiglu(module, swiglu_rows, swiglu_backend)
+            swiglu_modules.append(name)
+
+    if add_rms_norm_rows:
+        if add_rms_norm_backend == "adaptive":
+            from KERVRuntimeOptimization.adaptive_rms_norm import (
+                add_rms_norm_inference as fused_add_rms_norm,
+            )
+
+            add_rms_norm_implementation = "flagos_adaptive_add_rms_norm"
+        elif add_rms_norm_backend == "flag_gems":
+            import flag_gems
+
+            fused_add_rms_norm = flag_gems.fused_add_rms_norm
+            add_rms_norm_implementation = "flag_gems_fused_add_rms_norm"
+        elif add_rms_norm_backend == "native_inplace":
+            fused_add_rms_norm = None
+            add_rms_norm_implementation = "flagos_native_inplace_add_rms_norm"
+        elif add_rms_norm_backend == "flagos_kerv":
+            from KERVRuntimeOptimization.embodied_ops import kerv_add_rms_norm
+
+            def fused_add_rms_norm(
+                attention_output: torch.Tensor,
+                residual_input: torch.Tensor,
+                _shape,
+                norm_weight: torch.Tensor,
+                norm_eps: float,
+            ):
+                # The decoder needs the post-add residual for the second
+                # residual connection.  ``kerv_add_rms_norm`` intentionally
+                # returns only the normalized tensor and updates its first
+                # argument in place, so preserve the combined residual before
+                # invoking it.  This keeps the fusion numerically equivalent
+                # to ``residual + attention; rms_norm(residual)``.
+                combined_residual = attention_output + residual_input
+                normalized = kerv_add_rms_norm(
+                    attention_output,
+                    residual_input,
+                    norm_weight,
+                    norm_eps,
+                )
+                return normalized, combined_residual
+
+            add_rms_norm_implementation = "flagos_embodied_kerv_add_rms_norm"
+        else:
+            raise ValueError(f"unsupported Add-RMSNorm backend: {add_rms_norm_backend}")
+
+        for name, module in model.named_modules():
+            if _compatible_add_rms_norm_decoder(module, add_rms_norm_input_sizes):
+                _patch_fused_add_rms_norm(
+                    module,
+                    add_rms_norm_rows,
+                    fused_add_rms_norm,
+                    add_rms_norm_implementation,
+                )
+                add_rms_norm_modules.append(name)
+
+    return {
+        "qkv_group_count": len(qkv_modules),
+        "gate_up_group_count": len(gate_up_modules),
+        "total_group_count": len(groups),
+        "swiglu_module_count": len(swiglu_modules),
+        "add_rms_norm_module_count": len(add_rms_norm_modules),
+        "packed_weight_bytes": sum(group.packed_bytes for group in groups),
+        "qkv_fused_rows": list(qkv_rows),
+        "gate_up_fused_rows": list(gate_up_rows),
+        "qkv_input_sizes": list(qkv_input_sizes),
+        "gate_up_input_sizes": list(gate_up_input_sizes),
+        "swiglu_fused_rows": list(swiglu_rows),
+        "swiglu_input_sizes": list(swiglu_input_sizes),
+        "swiglu_backend": str(swiglu_backend),
+        "add_rms_norm_fused_rows": list(add_rms_norm_rows),
+        "add_rms_norm_input_sizes": list(add_rms_norm_input_sizes),
+        "add_rms_norm_backend": add_rms_norm_backend,
+        "qkv_modules": qkv_modules,
+        "gate_up_modules": gate_up_modules,
+        "swiglu_modules": swiglu_modules,
+        "add_rms_norm_modules": add_rms_norm_modules,
+    }
+
+
+def enable_linear_fusion(
+    model: nn.Module,
+    enabled: bool,
+    qkv_rows: str | None,
+    gate_up_rows: str | None,
+    qkv_input_sizes: str | None,
+    gate_up_input_sizes: str | None,
+    swiglu_rows: str | None,
+    swiglu_input_sizes: str | None,
+    swiglu_backend: str,
+    add_rms_norm_rows: str | None,
+    add_rms_norm_input_sizes: str | None,
+    add_rms_norm_backend: str,
+    record: bool,
+    record_once: bool,
+    log_path: str | None,
+    manifest_path: str | None,
+) -> dict[str, Any]:
+    """Install shape-routed inference fusion and persist an auditable manifest."""
+    parsed_qkv_rows = _parse_rows(qkv_rows)
+    parsed_gate_up_rows = _parse_rows(gate_up_rows)
+    parsed_qkv_input_sizes = _parse_rows(qkv_input_sizes)
+    parsed_gate_up_input_sizes = _parse_rows(gate_up_input_sizes)
+    parsed_swiglu_rows = _parse_rows(swiglu_rows)
+    parsed_swiglu_input_sizes = _parse_rows(swiglu_input_sizes)
+    parsed_add_rms_norm_rows = _parse_rows(add_rms_norm_rows)
+    parsed_add_rms_norm_input_sizes = _parse_rows(add_rms_norm_input_sizes)
+    manifest: dict[str, Any] = {
+        "enabled": bool(enabled),
+        "implementation": "flagos_grouped_cublas_linear",
+        "model_class": type(model).__name__,
+        "torch_version": torch.__version__,
+        "qkv_fused_rows": list(parsed_qkv_rows),
+        "gate_up_fused_rows": list(parsed_gate_up_rows),
+        "qkv_input_sizes": list(parsed_qkv_input_sizes),
+        "gate_up_input_sizes": list(parsed_gate_up_input_sizes),
+        "swiglu_fused_rows": list(parsed_swiglu_rows),
+        "swiglu_input_sizes": list(parsed_swiglu_input_sizes),
+        "swiglu_backend": str(swiglu_backend),
+        "add_rms_norm_fused_rows": list(parsed_add_rms_norm_rows),
+        "add_rms_norm_input_sizes": list(parsed_add_rms_norm_input_sizes),
+        "add_rms_norm_backend": str(add_rms_norm_backend),
+        "native_shape_fallback": True,
+        "inference_only": True,
+    }
+    if torch.cuda.is_available():
+        manifest["cuda_device"] = torch.cuda.get_device_name(torch.cuda.current_device())
+
+    if enabled:
+        if (
+            not parsed_qkv_rows
+            and not parsed_gate_up_rows
+            and not parsed_swiglu_rows
+            and not parsed_add_rms_norm_rows
+        ):
+            raise ValueError("transformer fusion is enabled but all row allowlists are empty")
+        if record and not log_path:
+            raise ValueError("linear fusion recording requires a log path")
+        configure_linear_fusion_recording(log_path, record, record_once)
+        installed = fuse_transformer_linears(
+            model,
+            qkv_rows=parsed_qkv_rows,
+            gate_up_rows=parsed_gate_up_rows,
+            qkv_input_sizes=parsed_qkv_input_sizes,
+            gate_up_input_sizes=parsed_gate_up_input_sizes,
+            swiglu_rows=parsed_swiglu_rows,
+            swiglu_input_sizes=parsed_swiglu_input_sizes,
+            swiglu_backend=str(swiglu_backend),
+            add_rms_norm_rows=parsed_add_rms_norm_rows,
+            add_rms_norm_input_sizes=parsed_add_rms_norm_input_sizes,
+            add_rms_norm_backend=str(add_rms_norm_backend),
+        )
+        if (
+            installed["total_group_count"] == 0
+            and installed["swiglu_module_count"] == 0
+            and installed["add_rms_norm_module_count"] == 0
+        ):
+            raise RuntimeError(
+                "transformer fusion found no compatible CUDA projection or SwiGLU modules"
+            )
+        manifest.update(installed)
+    else:
+        configure_linear_fusion_recording(None, False, record_once)
+        manifest.update(
+            {
+                "qkv_group_count": 0,
+                "gate_up_group_count": 0,
+                "total_group_count": 0,
+                "swiglu_module_count": 0,
+                "add_rms_norm_module_count": 0,
+                "packed_weight_bytes": 0,
+                "qkv_modules": [],
+                "gate_up_modules": [],
+                "swiglu_modules": [],
+                "add_rms_norm_modules": [],
+            }
+        )
+
+    if manifest_path:
+        path = Path(manifest_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(
+        "[FlagOS/LinearFusion] "
+        f"{'enabled' if enabled else 'disabled'}; "
+        f"qkv_rows={list(parsed_qkv_rows)}; gate_up_rows={list(parsed_gate_up_rows)}; "
+        f"swiglu_rows={list(parsed_swiglu_rows)}; groups={manifest['total_group_count']}; "
+        f"swiglu_backend={swiglu_backend}; "
+        f"swiglu_modules={manifest['swiglu_module_count']}; "
+        f"add_rms_norm_rows={list(parsed_add_rms_norm_rows)}; "
+        f"add_rms_norm_modules={manifest['add_rms_norm_module_count']}",
+        flush=True,
+    )
+    return manifest

--- a/flagscale/models/kerv/ops/KERVRuntimeOptimization/adaptive_rms_norm.py
+++ b/flagscale/models/kerv/ops/KERVRuntimeOptimization/adaptive_rms_norm.py
@@ -1,0 +1,360 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Inference-only RMSNorm kernel for small-batch embodied-model workloads.
+
+FlagGems provides the portable operator implementation.  This extension keeps
+the same RMSNorm semantics while removing training-only state allocation from
+the inference path.  Callers remain responsible for routing unsupported or
+unprofitable shapes to their native implementation.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+_TRITON_AVAILABLE = True
+try:
+    import triton
+    import triton.language as tl
+except Exception:  # pragma: no cover - exercised on non-Triton platforms.
+    _TRITON_AVAILABLE = False
+
+    class _TritonStub:
+        @staticmethod
+        def jit(function=None, **_kwargs):
+            if function is not None:
+                return function
+            return lambda candidate: candidate
+
+    class _LanguageStub:
+        constexpr = object()
+
+    triton = _TritonStub()
+    tl = _LanguageStub()
+
+
+_RECORD_PATH: Path | None = None
+_RECORD_ONCE = True
+_RECORDED_SHAPES: set[tuple[object, ...]] = set()
+_ORIGINAL_RMS_FORWARDS: dict[type, object] = {}
+
+
+def configure_adaptive_recording(
+    path: str | None,
+    record: bool,
+    once: bool = True,
+) -> None:
+    """Configure low-overhead, shape-level evidence for actual kernel hits."""
+    global _RECORD_PATH, _RECORD_ONCE
+    _RECORD_PATH = Path(path) if record and path else None
+    _RECORD_ONCE = bool(once)
+    _RECORDED_SHAPES.clear()
+    if _RECORD_PATH is not None:
+        _RECORD_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _RECORD_PATH.write_text("", encoding="utf-8")
+
+
+def _record_hit(input_tensor: torch.Tensor, columns: int) -> None:
+    if _RECORD_PATH is None:
+        return
+    key = (
+        tuple(input_tensor.shape),
+        tuple(input_tensor.stride()),
+        str(input_tensor.dtype),
+        columns,
+    )
+    if _RECORD_ONCE and key in _RECORDED_SHAPES:
+        return
+    _RECORDED_SHAPES.add(key)
+    record = {
+        "operator": "rms_norm",
+        "implementation": "flagos_adaptive_triton",
+        "shape": list(input_tensor.shape),
+        "stride": list(input_tensor.stride()),
+        "dtype": str(input_tensor.dtype).removeprefix("torch."),
+        "normalized_elements": columns,
+    }
+    with _RECORD_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record) + "\n")
+
+
+@triton.jit
+def _rms_norm_inference_kernel(
+    input_ptr,
+    weight_ptr,
+    output_ptr,
+    row_stride,
+    columns: tl.constexpr,
+    epsilon: tl.constexpr,
+    block_size: tl.constexpr,
+    round_before_weight: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, block_size)
+    mask = offsets < columns
+
+    values = tl.load(
+        input_ptr + row * row_stride + offsets,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    variance = tl.sum(values * values, axis=0) / columns
+    inverse_rms = 1.0 / tl.sqrt(variance + epsilon)
+
+    # Handwritten Qwen/Llama modules round before applying the learned weight,
+    # while aten::rms_norm keeps the calculation fused.  Both semantics occur
+    # in the two embodied workloads, so the rounding point is explicit.
+    if round_before_weight and tl.constexpr(input_ptr.dtype.element_ty == tl.bfloat16):
+        normalized = (values * inverse_rms).to(tl.bfloat16)
+    elif round_before_weight and tl.constexpr(input_ptr.dtype.element_ty == tl.float16):
+        normalized = (values * inverse_rms).to(tl.float16)
+    else:
+        normalized = values * inverse_rms
+
+    weights = tl.load(weight_ptr + offsets, mask=mask, other=0.0)
+    tl.store(
+        output_ptr + row * row_stride + offsets,
+        normalized * weights,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _add_rms_norm_inference_kernel(
+    input_ptr,
+    residual_ptr,
+    weight_ptr,
+    output_ptr,
+    row_stride,
+    columns: tl.constexpr,
+    epsilon: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    """Residual add plus RMSNorm with the native BF16 rounding points."""
+    row = tl.program_id(0)
+    offsets = tl.arange(0, block_size)
+    mask = offsets < columns
+    input_offsets = row * row_stride + offsets
+
+    values = tl.load(input_ptr + input_offsets, mask=mask, other=0.0).to(tl.float32)
+    residual = tl.load(residual_ptr + input_offsets, mask=mask, other=0.0).to(tl.float32)
+    summed = values + residual
+
+    # PyTorch produces the residual add in the input dtype before the
+    # handwritten Llama/Qwen RMSNorm promotes it to FP32. Reintroducing both
+    # BF16/FP16 rounding points avoids the token drift of generic fused kernels.
+    if tl.constexpr(input_ptr.dtype.element_ty == tl.bfloat16):
+        summed = summed.to(tl.bfloat16)
+    elif tl.constexpr(input_ptr.dtype.element_ty == tl.float16):
+        summed = summed.to(tl.float16)
+    # The attention output is disposable; retain the residual input because
+    # custom speculative decoders may keep aliases to it.
+    tl.store(input_ptr + input_offsets, summed, mask=mask)
+
+    summed_fp32 = summed.to(tl.float32)
+    variance = tl.sum(summed_fp32 * summed_fp32, axis=0) / columns
+    inverse_rms = tl.rsqrt(variance + epsilon)
+    normalized = summed_fp32 * inverse_rms
+    if tl.constexpr(input_ptr.dtype.element_ty == tl.bfloat16):
+        normalized = normalized.to(tl.bfloat16)
+    elif tl.constexpr(input_ptr.dtype.element_ty == tl.float16):
+        normalized = normalized.to(tl.float16)
+
+    weights = tl.load(weight_ptr + offsets, mask=mask, other=0.0)
+    tl.store(output_ptr + input_offsets, normalized * weights, mask=mask)
+
+
+def rms_norm_inference(
+    input_tensor: torch.Tensor,
+    normalized_shape: Iterable[int],
+    weight: torch.Tensor,
+    epsilon: float = 1e-6,
+    round_before_weight: bool = True,
+) -> torch.Tensor:
+    """Run a forward-only, one-kernel RMSNorm on contiguous CUDA tensors."""
+    if not _TRITON_AVAILABLE:
+        raise ValueError("adaptive RMSNorm requires Triton")
+    normalized_shape = tuple(int(value) for value in normalized_shape)
+    columns = math.prod(normalized_shape)
+    if not input_tensor.is_cuda or weight is None:
+        raise ValueError("adaptive RMSNorm requires a CUDA tensor and a weight")
+    if input_tensor.numel() % columns:
+        raise ValueError(f"input elements {input_tensor.numel()} are not divisible by {columns}")
+    if weight.numel() != columns:
+        raise ValueError(
+            f"weight elements {weight.numel()} do not match normalized shape {columns}"
+        )
+    if input_tensor.dtype not in (torch.bfloat16, torch.float16, torch.float32):
+        raise ValueError(f"unsupported adaptive RMSNorm dtype: {input_tensor.dtype}")
+
+    _record_hit(input_tensor, columns)
+    contiguous_input = input_tensor.contiguous()
+    contiguous_weight = weight.contiguous()
+    output = torch.empty_like(contiguous_input)
+    rows = contiguous_input.numel() // columns
+    block_size = triton.next_power_of_2(columns)
+    num_warps = 8 if block_size >= 4096 else 4
+    _rms_norm_inference_kernel[(rows,)](
+        contiguous_input,
+        contiguous_weight,
+        output,
+        columns,
+        columns=columns,
+        epsilon=float(epsilon),
+        block_size=block_size,
+        round_before_weight=bool(round_before_weight),
+        num_warps=num_warps,
+    )
+    return output.reshape(input_tensor.shape)
+
+
+def rms_norm_aten_inference(
+    input_tensor: torch.Tensor,
+    normalized_shape: Iterable[int],
+    weight: torch.Tensor,
+    epsilon: float = 1e-6,
+) -> torch.Tensor:
+    """Inference implementation matching fused ``aten::rms_norm`` semantics."""
+    return rms_norm_inference(
+        input_tensor,
+        normalized_shape,
+        weight,
+        epsilon,
+        round_before_weight=False,
+    )
+
+
+def add_rms_norm_inference(
+    input_tensor: torch.Tensor,
+    residual: torch.Tensor,
+    normalized_shape: Iterable[int],
+    weight: torch.Tensor,
+    epsilon: float = 1e-6,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fuse residual addition and handwritten Llama/Qwen RMSNorm in-place.
+
+    The disposable attention ``input_tensor`` is reused for the residual sum;
+    the original ``residual`` remains untouched because speculative decoders
+    may retain aliases to it. A separate normalized output is returned first.
+    """
+    if not _TRITON_AVAILABLE:
+        raise ValueError("adaptive Add-RMSNorm requires Triton")
+    normalized_shape = tuple(int(value) for value in normalized_shape)
+    columns = math.prod(normalized_shape)
+    if input_tensor.shape != residual.shape:
+        raise ValueError(
+            f"add RMSNorm input shapes must match: {input_tensor.shape} != {residual.shape}"
+        )
+    if not input_tensor.is_cuda or not residual.is_cuda or weight is None:
+        raise ValueError("adaptive Add-RMSNorm requires CUDA tensors and a weight")
+    if input_tensor.dtype != residual.dtype or input_tensor.dtype != weight.dtype:
+        raise ValueError("adaptive Add-RMSNorm requires a common input/weight dtype")
+    if input_tensor.dtype not in (torch.bfloat16, torch.float16, torch.float32):
+        raise ValueError(f"unsupported adaptive Add-RMSNorm dtype: {input_tensor.dtype}")
+    if input_tensor.numel() % columns or weight.numel() != columns:
+        raise ValueError("adaptive Add-RMSNorm normalized shape is incompatible")
+
+    contiguous_input = input_tensor.contiguous()
+    contiguous_residual = residual.contiguous()
+    contiguous_weight = weight.contiguous()
+    output = torch.empty_like(contiguous_input)
+    rows = contiguous_input.numel() // columns
+    block_size = triton.next_power_of_2(columns)
+    num_warps = 8 if block_size >= 4096 else 4
+    _add_rms_norm_inference_kernel[(rows,)](
+        contiguous_input,
+        contiguous_residual,
+        contiguous_weight,
+        output,
+        columns,
+        columns=columns,
+        epsilon=float(epsilon),
+        block_size=block_size,
+        num_warps=num_warps,
+    )
+    return (
+        output.reshape(input_tensor.shape),
+        contiguous_input.reshape(input_tensor.shape),
+    )
+
+
+def is_supported_rms_norm(
+    input_tensor: torch.Tensor,
+    normalized_shape: Iterable[int],
+    weight: torch.Tensor,
+) -> bool:
+    """Cheap routing predicate shared by the VLN and KERV adapters."""
+    normalized_shape = tuple(int(value) for value in normalized_shape)
+    columns = math.prod(normalized_shape)
+    return bool(
+        _TRITON_AVAILABLE
+        and input_tensor.is_cuda
+        and input_tensor.dtype in (torch.bfloat16, torch.float16, torch.float32)
+        and input_tensor.stride(-1) == 1
+        and input_tensor.numel() % columns == 0
+        and weight is not None
+        and weight.is_cuda
+        and weight.numel() == columns
+    )
+
+
+def install_llama_rms_norm_bridge(enabled: bool = True) -> int:
+    """Route handwritten verifier RMSNorm modules through the fused operator."""
+
+    if not enabled:
+        for module_class, original in tuple(_ORIGINAL_RMS_FORWARDS.items()):
+            module_class.forward = original
+        _ORIGINAL_RMS_FORWARDS.clear()
+        return 0
+
+    classes = []
+    from transformers.models.llama import modeling_llama as hf_modeling_llama
+
+    classes.append(hf_modeling_llama.LlamaRMSNorm)
+    try:
+        from openvla.specdecoding.model import modeling_llama_kv
+    except ImportError:
+        pass
+    else:
+        classes.append(modeling_llama_kv.LlamaRMSNorm)
+
+    for module_class in classes:
+        if module_class in _ORIGINAL_RMS_FORWARDS:
+            continue
+        original = module_class.forward
+        _ORIGINAL_RMS_FORWARDS[module_class] = original
+
+        def flagos_rms_forward(self, hidden_states, _original=original):
+            weight = self.weight
+            if is_supported_rms_norm(hidden_states, (weight.numel(),), weight):
+                return rms_norm_inference(
+                    hidden_states,
+                    (weight.numel(),),
+                    weight,
+                    float(getattr(self, "variance_epsilon", 1e-6)),
+                    round_before_weight=True,
+                )
+            return _original(self, hidden_states)
+
+        module_class.forward = flagos_rms_forward
+    return len(classes)

--- a/flagscale/models/kerv/ops/KERVRuntimeOptimization/adaptive_rotary_fusion.py
+++ b/flagscale/models/kerv/ops/KERVRuntimeOptimization/adaptive_rotary_fusion.py
@@ -1,0 +1,744 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""KERV verifier/drafter RoPE fusion for FlagOS.
+
+The stock path gathers cos/sin, materializes ``rotate_half`` twice, launches
+four pointwise kernels, and writes intermediate tensors.  This inference-only
+operator performs the position gather and both Q/K rotations in one Triton
+launch while preserving KERV's native ``[B,H,S,D]`` layout.
+"""
+
+from __future__ import annotations
+
+import json
+from contextvars import ContextVar
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_TRITON_AVAILABLE = True
+try:
+    import triton
+    import triton.language as tl
+except Exception:  # pragma: no cover - exercised on non-Triton platforms.
+    _TRITON_AVAILABLE = False
+
+    class _TritonStub:
+        __version__ = None
+
+        @staticmethod
+        def jit(function=None, **_kwargs):
+            if function is not None:
+                return function
+            return lambda candidate: candidate
+
+    class _LanguageStub:
+        constexpr = object()
+
+    triton = _TritonStub()
+    tl = _LanguageStub()
+
+
+_RECORD_PATH: Path | None = None
+_RECORD_ONCE = True
+_RECORDED: set[tuple[object, ...]] = set()
+_ORIGINALS: dict[object, Callable[..., object]] = {}
+_ORIGINALS_L31: dict[object, Callable[..., object]] = {}
+_ORIGINALS_DIRECT: dict[tuple[object, str], Callable[..., object]] = {}
+_ORIGINAL_ATTENTION_FORWARDS: dict[type, Callable[..., object]] = {}
+_ROTARY_KEY_DESTINATION: ContextVar[torch.Tensor | None] = ContextVar(
+    "flagos_rotary_key_destination", default=None
+)
+_ROTARY_VALUE_DESTINATION: ContextVar[torch.Tensor | None] = ContextVar(
+    "flagos_rotary_value_destination", default=None
+)
+_ROTARY_VALUE_SOURCE: ContextVar[torch.Tensor | None] = ContextVar(
+    "flagos_rotary_value_source", default=None
+)
+_ROTARY_CACHE_CONTEXT: ContextVar[tuple[object, int, int] | None] = ContextVar(
+    "flagos_rotary_cache_context", default=None
+)
+_ORIGINAL_INSTANCE_FORWARDS: dict[object, Callable[..., object]] = {}
+_VALUE_CAPTURE_HANDLES: list[object] = []
+_RESIDENT_KEY_WRITE_ENABLED = True
+
+
+@triton.jit(do_not_specialize=["sequence"])
+def _rotary_qk_bhsd_kernel(
+    q_ptr,
+    k_ptr,
+    cos_ptr,
+    sin_ptr,
+    position_ptr,
+    output_q_ptr,
+    output_k_ptr,
+    q_stride_b: tl.constexpr,
+    q_stride_h: tl.constexpr,
+    q_stride_s: tl.constexpr,
+    q_stride_d: tl.constexpr,
+    k_stride_b: tl.constexpr,
+    k_stride_h: tl.constexpr,
+    k_stride_s: tl.constexpr,
+    k_stride_d: tl.constexpr,
+    oq_stride_b: tl.constexpr,
+    oq_stride_h: tl.constexpr,
+    oq_stride_s: tl.constexpr,
+    oq_stride_d: tl.constexpr,
+    ok_stride_b: tl.constexpr,
+    ok_stride_h: tl.constexpr,
+    ok_stride_s: tl.constexpr,
+    ok_stride_d: tl.constexpr,
+    cos_stride_b: tl.constexpr,
+    cos_stride_s: tl.constexpr,
+    sin_stride_b: tl.constexpr,
+    sin_stride_s: tl.constexpr,
+    indexed: tl.constexpr,
+    sequence,
+    q_heads: tl.constexpr,
+    k_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    block: tl.constexpr,
+):
+    token = tl.program_id(0)
+    batch_id = token // sequence
+    sequence_id = token % sequence
+    if indexed:
+        position = tl.load(position_ptr + batch_id * sequence + sequence_id)
+        cos_offset = position * cos_stride_s
+        sin_offset = position * sin_stride_s
+    else:
+        cos_offset = batch_id * cos_stride_b + sequence_id * cos_stride_s
+        sin_offset = batch_id * sin_stride_b + sequence_id * sin_stride_s
+    dims = tl.arange(0, block)
+    mask = dims < head_dim
+    half = head_dim // 2
+    rotated_dims = (dims + half) % head_dim
+    cos = tl.load(cos_ptr + cos_offset + dims, mask=mask, other=0.0).to(tl.float32)
+    sin = tl.load(sin_ptr + sin_offset + dims, mask=mask, other=0.0).to(tl.float32)
+    sin = tl.where(dims < half, -sin, sin)
+
+    for head in range(0, q_heads):
+        source = batch_id * q_stride_b + head * q_stride_h + sequence_id * q_stride_s
+        target = batch_id * oq_stride_b + head * oq_stride_h + sequence_id * oq_stride_s
+        value = tl.load(q_ptr + source + dims * q_stride_d, mask=mask, other=0.0)
+        rotated = tl.load(q_ptr + source + rotated_dims * q_stride_d, mask=mask, other=0.0)
+        tl.store(
+            output_q_ptr + target + dims * oq_stride_d,
+            value * cos + rotated * sin,
+            mask=mask,
+        )
+
+    for head in range(0, k_heads):
+        source = batch_id * k_stride_b + head * k_stride_h + sequence_id * k_stride_s
+        target = batch_id * ok_stride_b + head * ok_stride_h + sequence_id * ok_stride_s
+        value = tl.load(k_ptr + source + dims * k_stride_d, mask=mask, other=0.0)
+        rotated = tl.load(k_ptr + source + rotated_dims * k_stride_d, mask=mask, other=0.0)
+        tl.store(
+            output_k_ptr + target + dims * ok_stride_d,
+            value * cos + rotated * sin,
+            mask=mask,
+        )
+
+
+@triton.jit(do_not_specialize=["sequence"])
+def _rotary_qk_bhsd_head_kernel(
+    q_ptr,
+    k_ptr,
+    cos_ptr,
+    sin_ptr,
+    position_ptr,
+    output_q_ptr,
+    output_k_ptr,
+    q_stride_b: tl.constexpr,
+    q_stride_h: tl.constexpr,
+    q_stride_s: tl.constexpr,
+    q_stride_d: tl.constexpr,
+    k_stride_b: tl.constexpr,
+    k_stride_h: tl.constexpr,
+    k_stride_s: tl.constexpr,
+    k_stride_d: tl.constexpr,
+    oq_stride_b: tl.constexpr,
+    oq_stride_h: tl.constexpr,
+    oq_stride_s: tl.constexpr,
+    oq_stride_d: tl.constexpr,
+    ok_stride_b: tl.constexpr,
+    ok_stride_h: tl.constexpr,
+    ok_stride_s: tl.constexpr,
+    ok_stride_d: tl.constexpr,
+    cos_stride_b: tl.constexpr,
+    cos_stride_s: tl.constexpr,
+    sin_stride_b: tl.constexpr,
+    sin_stride_s: tl.constexpr,
+    indexed: tl.constexpr,
+    sequence,
+    q_heads: tl.constexpr,
+    k_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    block: tl.constexpr,
+):
+    """Expose heads as programs so batch=1, sequence=1 still fills the GPU."""
+
+    token = tl.program_id(0)
+    head = tl.program_id(1)
+    batch_id = token // sequence
+    sequence_id = token % sequence
+    if indexed:
+        position = tl.load(position_ptr + batch_id * sequence + sequence_id)
+        cos_offset = position * cos_stride_s
+        sin_offset = position * sin_stride_s
+    else:
+        cos_offset = batch_id * cos_stride_b + sequence_id * cos_stride_s
+        sin_offset = batch_id * sin_stride_b + sequence_id * sin_stride_s
+    dims = tl.arange(0, block)
+    mask = dims < head_dim
+    half = head_dim // 2
+    rotated_dims = (dims + half) % head_dim
+    cos = tl.load(cos_ptr + cos_offset + dims, mask=mask, other=0.0).to(tl.float32)
+    sin = tl.load(sin_ptr + sin_offset + dims, mask=mask, other=0.0).to(tl.float32)
+    sin = tl.where(dims < half, -sin, sin)
+
+    q_mask = mask & (head < q_heads)
+    q_source = batch_id * q_stride_b + head * q_stride_h + sequence_id * q_stride_s
+    q_target = batch_id * oq_stride_b + head * oq_stride_h + sequence_id * oq_stride_s
+    q_value = tl.load(q_ptr + q_source + dims * q_stride_d, mask=q_mask, other=0.0)
+    q_rotated = tl.load(
+        q_ptr + q_source + rotated_dims * q_stride_d,
+        mask=q_mask,
+        other=0.0,
+    )
+    tl.store(
+        output_q_ptr + q_target + dims * oq_stride_d,
+        q_value * cos + q_rotated * sin,
+        mask=q_mask,
+    )
+
+    k_mask = mask & (head < k_heads)
+    k_source = batch_id * k_stride_b + head * k_stride_h + sequence_id * k_stride_s
+    k_target = batch_id * ok_stride_b + head * ok_stride_h + sequence_id * ok_stride_s
+    k_value = tl.load(k_ptr + k_source + dims * k_stride_d, mask=k_mask, other=0.0)
+    k_rotated = tl.load(
+        k_ptr + k_source + rotated_dims * k_stride_d,
+        mask=k_mask,
+        other=0.0,
+    )
+    tl.store(
+        output_k_ptr + k_target + dims * ok_stride_d,
+        k_value * cos + k_rotated * sin,
+        mask=k_mask,
+    )
+
+
+def _supported(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+) -> bool:
+    return bool(
+        _TRITON_AVAILABLE
+        and query.is_cuda
+        and key.is_cuda
+        and query.ndim == 4
+        and key.ndim == 4
+        and query.shape[0] == key.shape[0] == 1
+        and query.shape[2:] == key.shape[2:]
+        and query.shape[-1] == 128
+        and query.dtype in (torch.float16, torch.bfloat16)
+        and key.dtype == query.dtype
+        and query.stride(-1) == 1
+        and key.stride(-1) == 1
+        and position_ids.is_cuda
+        and position_ids.is_contiguous()
+        and position_ids.shape == (query.shape[0], query.shape[2])
+        and position_ids.dtype in (torch.int32, torch.int64)
+        and cos.is_cuda
+        and sin.is_cuda
+    )
+
+
+def fused_rotary_qk(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fuse table gather, split-half rotation, and Q/K output writes."""
+
+    if not _supported(query, key, cos, sin, position_ids):
+        raise ValueError("unsupported KERV rotary layout")
+    full_cos = cos.squeeze(0).squeeze(0).contiguous()
+    full_sin = sin.squeeze(0).squeeze(0).contiguous()
+    if full_cos.ndim != 2 or full_cos.shape[-1] != query.shape[-1]:
+        raise ValueError("rotary tables must be [max_sequence, head_dim]")
+
+    # Native RoPE arithmetic returns dense outputs even when Q/K are transposed
+    # views.  Match that contract while accepting the verifier's strided input.
+    output_q = torch.empty(query.shape, device=query.device, dtype=query.dtype)
+    output_k = torch.empty(key.shape, device=key.device, dtype=key.dtype)
+    block = triton.next_power_of_2(query.shape[-1])
+    common_args = (
+        query,
+        key,
+        full_cos,
+        full_sin,
+        position_ids,
+        output_q,
+        output_k,
+        *query.stride(),
+        *key.stride(),
+        *output_q.stride(),
+        *output_k.stride(),
+        0,
+        full_cos.stride(0),
+        0,
+        full_sin.stride(0),
+        True,
+        query.shape[2],
+        query.shape[1],
+        key.shape[1],
+        query.shape[-1],
+        block,
+    )
+    # Long prompts have enough token-level parallelism and benefit from loading
+    # each cos/sin row once.  Decode/tree steps are short, so parallelize heads
+    # to avoid one Triton program serially rotating all 32 attention heads.
+    if query.shape[2] <= 8:
+        _rotary_qk_bhsd_head_kernel[
+            (query.shape[0] * query.shape[2], max(query.shape[1], key.shape[1]))
+        ](
+            *common_args,
+            num_warps=1,
+            num_stages=1,
+        )
+    else:
+        _rotary_qk_bhsd_kernel[(query.shape[0] * query.shape[2],)](
+            *common_args,
+            num_warps=4,
+            num_stages=1,
+        )
+    return output_q, output_k
+
+
+def fused_rotary_qk_direct(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    *,
+    output_key: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fuse LLaMA-3.1 RoPE when cos/sin are already selected as [B,S,D]."""
+
+    supported = bool(
+        _TRITON_AVAILABLE
+        and query.is_cuda
+        and key.is_cuda
+        and query.ndim == 4
+        and key.ndim == 4
+        and query.shape[0] == key.shape[0] == 1
+        and query.shape[2:] == key.shape[2:]
+        and query.shape[-1] == 128
+        and query.dtype in (torch.float16, torch.bfloat16)
+        and key.dtype == query.dtype
+        and query.stride(-1) == 1
+        and key.stride(-1) == 1
+        and cos.is_cuda
+        and sin.is_cuda
+        and cos.dtype == query.dtype
+        and sin.dtype == query.dtype
+        and cos.shape == sin.shape == (query.shape[0], query.shape[2], query.shape[3])
+        and cos.stride(-1) == 1
+        and sin.stride(-1) == 1
+    )
+    if not supported:
+        raise ValueError("unsupported KERV LLaMA-3.1 rotary layout")
+
+    output_q = torch.empty(query.shape, device=query.device, dtype=query.dtype)
+    if output_key is None:
+        output_k = torch.empty(key.shape, device=key.device, dtype=key.dtype)
+    else:
+        if (
+            output_key.shape != key.shape
+            or output_key.device != key.device
+            or output_key.dtype != key.dtype
+            or output_key.stride(-1) != 1
+        ):
+            raise ValueError("resident rotary K destination is incompatible")
+        output_k = output_key
+    block = triton.next_power_of_2(query.shape[-1])
+    common_args = (
+        query,
+        key,
+        cos,
+        sin,
+        cos,  # Unused dummy pointer for the non-indexed specialization.
+        output_q,
+        output_k,
+        *query.stride(),
+        *key.stride(),
+        *output_q.stride(),
+        *output_k.stride(),
+        cos.stride(0),
+        cos.stride(1),
+        sin.stride(0),
+        sin.stride(1),
+        False,
+        query.shape[2],
+        query.shape[1],
+        key.shape[1],
+        query.shape[-1],
+        block,
+    )
+    if query.shape[2] <= 8:
+        _rotary_qk_bhsd_head_kernel[
+            (query.shape[0] * query.shape[2], max(query.shape[1], key.shape[1]))
+        ](*common_args, num_warps=1, num_stages=1)
+    else:
+        _rotary_qk_bhsd_kernel[(query.shape[0] * query.shape[2],)](
+            *common_args, num_warps=4, num_stages=1
+        )
+    return output_q, output_k
+
+
+def _record(kind: str, query: torch.Tensor, key: torch.Tensor) -> None:
+    if _RECORD_PATH is None:
+        return
+    record_key = (kind, tuple(query.shape), tuple(key.shape), str(query.dtype))
+    if _RECORD_ONCE and record_key in _RECORDED:
+        return
+    _RECORDED.add(record_key)
+    payload = {
+        "operator": "fused_rotary_qk",
+        "scope": kind,
+        "implementation": "flagos_triton_adaptive_bhsd_rotary_qk",
+        "query_shape": list(query.shape),
+        "key_shape": list(key.shape),
+        "dtype": str(query.dtype).removeprefix("torch."),
+    }
+    with _RECORD_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload) + "\n")
+
+
+def _install(module: object, scope: str) -> None:
+    original = module.apply_rotary_pos_emb
+    if module in _ORIGINALS:
+        return
+    _ORIGINALS[module] = original
+
+    def adaptive(query, key, cos, sin, position_ids):
+        if _supported(query, key, cos, sin, position_ids):
+            _record(scope, query, key)
+            return fused_rotary_qk(query, key, cos, sin, position_ids)
+        return original(query, key, cos, sin, position_ids)
+
+    module.apply_rotary_pos_emb = adaptive
+
+
+def _install_l31(module: object, scope: str) -> None:
+    if not hasattr(module, "apply_rotary_pos_emb_L31") or module in _ORIGINALS_L31:
+        return
+    original = module.apply_rotary_pos_emb_L31
+    _ORIGINALS_L31[module] = original
+
+    def adaptive(query, key, cos, sin, position_ids=None, unsqueeze_dim=1):
+        del position_ids
+        supported = bool(
+            unsqueeze_dim == 1
+            and query.is_cuda
+            and key.is_cuda
+            and query.ndim == 4
+            and key.ndim == 4
+            and cos.shape == sin.shape == (query.shape[0], query.shape[2], query.shape[3])
+        )
+        if supported:
+            try:
+                result = fused_rotary_qk_direct(query, key, cos, sin)
+            except ValueError:
+                pass
+            else:
+                _record(scope, query, key)
+                return result
+        return original(query, key, cos, sin, None, unsqueeze_dim)
+
+    module.apply_rotary_pos_emb_L31 = adaptive
+
+
+def _install_direct(module: object, attribute: str, scope: str) -> None:
+    key = (module, attribute)
+    if not hasattr(module, attribute) or key in _ORIGINALS_DIRECT:
+        return
+    original = getattr(module, attribute)
+    _ORIGINALS_DIRECT[key] = original
+
+    def adaptive(query, key_tensor, cos, sin, position_ids=None, unsqueeze_dim=1):
+        supported = bool(
+            unsqueeze_dim == 1
+            and query.is_cuda
+            and key_tensor.is_cuda
+            and query.ndim == 4
+            and key_tensor.ndim == 4
+            and cos.shape == sin.shape == (query.shape[0], query.shape[2], query.shape[3])
+        )
+        if supported:
+            resident_key = _ROTARY_KEY_DESTINATION.get()
+            resident_value = _ROTARY_VALUE_DESTINATION.get()
+            value_source = _ROTARY_VALUE_SOURCE.get()
+            cache_context = _ROTARY_CACHE_CONTEXT.get()
+            if (
+                resident_key is not None
+                and resident_value is not None
+                and value_source is not None
+                and cache_context is not None
+            ):
+                cache, layer_idx, token_count = cache_context
+                try:
+                    value_states = value_source.view(
+                        query.shape[0],
+                        query.shape[2],
+                        key_tensor.shape[1],
+                        query.shape[3],
+                    ).transpose(1, 2)
+                    query_output = torch.ops.flagos_embodied.kerv_rope_kv_store(
+                        query,
+                        key_tensor,
+                        value_states,
+                        cos,
+                        sin,
+                        cache.empty_position_ids,
+                        resident_key,
+                        resident_value,
+                        0,
+                    )
+                    cache.mark_rotary_value_written(layer_idx, token_count)
+                except (RuntimeError, ValueError, AttributeError):
+                    pass
+                else:
+                    _record(f"{scope}_resident_kv", query, key_tensor)
+                    return query_output, resident_key
+            try:
+                result = fused_rotary_qk_direct(
+                    query,
+                    key_tensor,
+                    cos,
+                    sin,
+                    output_key=resident_key,
+                )
+            except ValueError:
+                pass
+            else:
+                _record(
+                    f"{scope}_resident_key" if resident_key is not None else scope,
+                    query,
+                    key_tensor,
+                )
+                return result
+        return original(query, key_tensor, cos, sin, position_ids, unsqueeze_dim)
+
+    setattr(module, attribute, adaptive)
+
+
+def _install_resident_kv_instance(attention: object) -> None:
+    """Expose both K and V resident slots around one attention invocation."""
+
+    if attention in _ORIGINAL_INSTANCE_FORWARDS:
+        return
+    original = attention.forward
+    _ORIGINAL_INSTANCE_FORWARDS[attention] = original
+
+    def capture_value(_module, _inputs, output):
+        if _ROTARY_VALUE_DESTINATION.get() is not None:
+            _ROTARY_VALUE_SOURCE.set(output)
+
+    _VALUE_CAPTURE_HANDLES.append(attention.v_proj.register_forward_hook(capture_value))
+
+    def flagos_attention_forward(self, hidden_states, *args, **kwargs):
+        cache = kwargs.get("past_key_value")
+        if cache is None and len(args) >= 3:
+            cache = args[2]
+        cache = getattr(self, "past_key_value", cache)
+        key_destination = None
+        value_destination = None
+        cache_context = None
+        if (
+            _RESIDENT_KEY_WRITE_ENABLED
+            and getattr(cache, "_flagos_persistent_tree_cache", False)
+            and hasattr(cache, "rotary_value_destination")
+        ):
+            token_count = int(hidden_states.shape[1])
+            layer_idx = int(self.layer_idx)
+            key_destination = cache.rotary_key_destination(layer_idx, token_count)
+            value_destination = cache.rotary_value_destination(layer_idx, token_count)
+            cache_context = (cache, layer_idx, token_count)
+        key_token = _ROTARY_KEY_DESTINATION.set(key_destination)
+        value_token = _ROTARY_VALUE_DESTINATION.set(value_destination)
+        source_token = _ROTARY_VALUE_SOURCE.set(None)
+        cache_token = _ROTARY_CACHE_CONTEXT.set(cache_context)
+        try:
+            return original(hidden_states, *args, **kwargs)
+        finally:
+            _ROTARY_CACHE_CONTEXT.reset(cache_token)
+            _ROTARY_VALUE_SOURCE.reset(source_token)
+            _ROTARY_VALUE_DESTINATION.reset(value_token)
+            _ROTARY_KEY_DESTINATION.reset(key_token)
+
+    attention.forward = flagos_attention_forward.__get__(attention, type(attention))
+
+
+def _install_resident_key_context(attention_class: type) -> None:
+    """Expose the current persistent-cache K slot to the fused RoPE call."""
+
+    if attention_class in _ORIGINAL_ATTENTION_FORWARDS:
+        return
+    original = attention_class.forward
+    _ORIGINAL_ATTENTION_FORWARDS[attention_class] = original
+
+    def flagos_attention_forward(self, hidden_states, *args, **kwargs):
+        cache = kwargs.get("past_key_value")
+        # Positional order after hidden_states: attention_mask, position_ids,
+        # past_key_value.  Most KERV calls use keywords, but retain both forms.
+        if cache is None and len(args) >= 3:
+            cache = args[2]
+        cache = getattr(self, "past_key_value", cache)
+        destination = None
+        if (
+            _RESIDENT_KEY_WRITE_ENABLED
+            and getattr(cache, "_flagos_persistent_tree_cache", False)
+            and hasattr(cache, "rotary_key_destination")
+        ):
+            destination = cache.rotary_key_destination(
+                int(self.layer_idx), int(hidden_states.shape[1])
+            )
+        token = _ROTARY_KEY_DESTINATION.set(destination)
+        try:
+            return original(self, hidden_states, *args, **kwargs)
+        finally:
+            _ROTARY_KEY_DESTINATION.reset(token)
+
+    attention_class.forward = flagos_attention_forward
+
+
+def _restore() -> None:
+    """Restore native module functions when the runtime switch is disabled."""
+
+    for module, original in tuple(_ORIGINALS.items()):
+        module.apply_rotary_pos_emb = original
+    _ORIGINALS.clear()
+    for module, original in tuple(_ORIGINALS_L31.items()):
+        module.apply_rotary_pos_emb_L31 = original
+    _ORIGINALS_L31.clear()
+    for (module, attribute), original in tuple(_ORIGINALS_DIRECT.items()):
+        setattr(module, attribute, original)
+    _ORIGINALS_DIRECT.clear()
+    for attention_class, original in tuple(_ORIGINAL_ATTENTION_FORWARDS.items()):
+        attention_class.forward = original
+    _ORIGINAL_ATTENTION_FORWARDS.clear()
+    for attention, original in tuple(_ORIGINAL_INSTANCE_FORWARDS.items()):
+        attention.forward = original
+    _ORIGINAL_INSTANCE_FORWARDS.clear()
+    for handle in _VALUE_CAPTURE_HANDLES:
+        handle.remove()
+    _VALUE_CAPTURE_HANDLES.clear()
+
+
+def enable_rotary_fusion(
+    enabled: bool,
+    resident_key_write: bool = True,
+    record: bool = True,
+    record_once: bool = True,
+    log_path: str | None = None,
+    manifest_path: str | None = None,
+    model=None,
+) -> dict[str, Any]:
+    """Install KERV verifier and drafter adapters after their modules import."""
+
+    global _RECORD_PATH, _RECORD_ONCE, _RESIDENT_KEY_WRITE_ENABLED
+    _RESIDENT_KEY_WRITE_ENABLED = bool(resident_key_write)
+    if record and enabled and not log_path:
+        raise ValueError("rotary fusion recording requires log_path")
+    _RECORD_PATH = Path(log_path) if enabled and record and log_path else None
+    _RECORD_ONCE = bool(record_once)
+    _RECORDED.clear()
+    if _RECORD_PATH is not None:
+        _RECORD_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _RECORD_PATH.write_text("", encoding="utf-8")
+
+    scopes: list[str] = []
+    if enabled:
+        from openvla.specdecoding.model import cnets, modeling_llama_kv
+        from transformers.models.llama import modeling_llama as hf_modeling_llama
+
+        _install(modeling_llama_kv, "verifier")
+        _install_l31(modeling_llama_kv, "verifier_l31")
+        _install_direct(hf_modeling_llama, "apply_rotary_pos_emb", "verifier_hf")
+        for attention_name in (
+            "LlamaAttention",
+            "LlamaFlashAttention2",
+            "LlamaSdpaAttention",
+        ):
+            attention_class = getattr(hf_modeling_llama, attention_name, None)
+            if attention_class is not None:
+                _install_resident_key_context(attention_class)
+        if model is not None:
+            language_model = getattr(getattr(model, "base_model", None), "language_model", None)
+            if language_model is not None:
+                for module in language_model.modules():
+                    if all(
+                        hasattr(module, attribute)
+                        for attribute in (
+                            "q_proj",
+                            "k_proj",
+                            "v_proj",
+                            "o_proj",
+                            "layer_idx",
+                        )
+                    ):
+                        _install_resident_kv_instance(module)
+        scopes.append("verifier")
+        _install(cnets, "drafter")
+        scopes.append("drafter")
+    else:
+        _restore()
+
+    manifest: dict[str, Any] = {
+        "enabled": bool(enabled),
+        "operator": "fused_rotary_qk",
+        "implementation": "flagos_triton_adaptive_bhsd_rotary_qk",
+        "scopes": scopes,
+        "supported_layout": "B,H,S,128",
+        "supported_dtypes": ["float16", "bfloat16"],
+        "native_fallback": True,
+        "resident_key_write": bool(resident_key_write),
+        "resident_value_write": bool(resident_key_write),
+        "inference_only": True,
+        "torch_version": torch.__version__,
+        "triton_version": getattr(triton, "__version__", None),
+    }
+    if torch.cuda.is_available():
+        manifest["cuda_device"] = torch.cuda.get_device_name(torch.cuda.current_device())
+    if manifest_path:
+        target = Path(manifest_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(
+        f"[FlagOS/RotaryFusion] {'enabled' if enabled else 'disabled'}; scopes={scopes}",
+        flush=True,
+    )
+    return manifest

--- a/flagscale/models/kerv/ops/KERVRuntimeOptimization/adaptive_rotary_fusion.py
+++ b/flagscale/models/kerv/ops/KERVRuntimeOptimization/adaptive_rotary_fusion.py
@@ -138,9 +138,20 @@ def _rotary_qk_bhsd_kernel(
         target = batch_id * oq_stride_b + head * oq_stride_h + sequence_id * oq_stride_s
         value = tl.load(q_ptr + source + dims * q_stride_d, mask=mask, other=0.0)
         rotated = tl.load(q_ptr + source + rotated_dims * q_stride_d, mask=mask, other=0.0)
+        left = value.to(tl.float32) * cos
+        right = rotated.to(tl.float32) * sin
+        # PyTorch materializes both BF16/FP16 products before the final add.
+        # Preserve that rounding order so fusion does not perturb verifier
+        # hidden states near an acceptance boundary.
+        if tl.constexpr(q_ptr.dtype.element_ty == tl.bfloat16):
+            left = left.to(tl.bfloat16)
+            right = right.to(tl.bfloat16)
+        elif tl.constexpr(q_ptr.dtype.element_ty == tl.float16):
+            left = left.to(tl.float16)
+            right = right.to(tl.float16)
         tl.store(
             output_q_ptr + target + dims * oq_stride_d,
-            value * cos + rotated * sin,
+            left + right,
             mask=mask,
         )
 
@@ -149,9 +160,17 @@ def _rotary_qk_bhsd_kernel(
         target = batch_id * ok_stride_b + head * ok_stride_h + sequence_id * ok_stride_s
         value = tl.load(k_ptr + source + dims * k_stride_d, mask=mask, other=0.0)
         rotated = tl.load(k_ptr + source + rotated_dims * k_stride_d, mask=mask, other=0.0)
+        left = value.to(tl.float32) * cos
+        right = rotated.to(tl.float32) * sin
+        if tl.constexpr(k_ptr.dtype.element_ty == tl.bfloat16):
+            left = left.to(tl.bfloat16)
+            right = right.to(tl.bfloat16)
+        elif tl.constexpr(k_ptr.dtype.element_ty == tl.float16):
+            left = left.to(tl.float16)
+            right = right.to(tl.float16)
         tl.store(
             output_k_ptr + target + dims * ok_stride_d,
-            value * cos + rotated * sin,
+            left + right,
             mask=mask,
         )
 
@@ -222,9 +241,17 @@ def _rotary_qk_bhsd_head_kernel(
         mask=q_mask,
         other=0.0,
     )
+    q_left = q_value.to(tl.float32) * cos
+    q_right = q_rotated.to(tl.float32) * sin
+    if tl.constexpr(q_ptr.dtype.element_ty == tl.bfloat16):
+        q_left = q_left.to(tl.bfloat16)
+        q_right = q_right.to(tl.bfloat16)
+    elif tl.constexpr(q_ptr.dtype.element_ty == tl.float16):
+        q_left = q_left.to(tl.float16)
+        q_right = q_right.to(tl.float16)
     tl.store(
         output_q_ptr + q_target + dims * oq_stride_d,
-        q_value * cos + q_rotated * sin,
+        q_left + q_right,
         mask=q_mask,
     )
 
@@ -237,9 +264,17 @@ def _rotary_qk_bhsd_head_kernel(
         mask=k_mask,
         other=0.0,
     )
+    k_left = k_value.to(tl.float32) * cos
+    k_right = k_rotated.to(tl.float32) * sin
+    if tl.constexpr(k_ptr.dtype.element_ty == tl.bfloat16):
+        k_left = k_left.to(tl.bfloat16)
+        k_right = k_right.to(tl.bfloat16)
+    elif tl.constexpr(k_ptr.dtype.element_ty == tl.float16):
+        k_left = k_left.to(tl.float16)
+        k_right = k_right.to(tl.float16)
     tl.store(
         output_k_ptr + k_target + dims * ok_stride_d,
-        k_value * cos + k_rotated * sin,
+        k_left + k_right,
         mask=k_mask,
     )
 

--- a/flagscale/models/kerv/ops/KERVRuntimeOptimization/embodied_ops/__init__.py
+++ b/flagscale/models/kerv/ops/KERVRuntimeOptimization/embodied_ops/__init__.py
@@ -1,0 +1,79 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""KERV-specific runtime operators.
+
+The package deliberately keeps the public surface small.  Every operator has
+an explicit native fallback and can be selected by the FlagScale runtime
+without changing the model's numerical control flow.
+"""
+
+from .kerv_ops import (
+    kerv_action_projection_select,
+    kerv_add_rms_norm,
+    kerv_kv_commit,
+    kerv_silu_mul,
+    kerv_static_tree_pack,
+    kerv_value_cache_store,
+    kerv_verify_accept_control,
+    register_kerv_ops,
+)
+from .phase2_ops import (
+    kerv_action_verify_accept,
+    kerv_down_proj_residual_rms_norm,
+    kerv_draft_action_topk,
+    kerv_kv_accept_commit,
+    kerv_logical_kv_commit,
+    kerv_o_proj_residual_rms_norm,
+    kerv_rope_kv_store,
+    kerv_tree_embed_pack,
+    kerv_vision_add_layer_norm,
+    kerv_vision_bias_gelu,
+)
+from .runtime import configure_kerv_ops, kerv_ops_manifest
+from .static_tree_attention import (
+    install_static_tree_attention,
+    static_tree_attention,
+    static_tree_attention_reference,
+)
+
+# Python-level spelling mirrors the public torch operator name.
+kerv_static_tree_attention = static_tree_attention
+
+__all__ = [
+    "configure_kerv_ops",
+    "kerv_action_projection_select",
+    "kerv_action_verify_accept",
+    "kerv_add_rms_norm",
+    "kerv_draft_action_topk",
+    "kerv_down_proj_residual_rms_norm",
+    "kerv_kv_commit",
+    "kerv_kv_accept_commit",
+    "kerv_logical_kv_commit",
+    "kerv_ops_manifest",
+    "kerv_o_proj_residual_rms_norm",
+    "kerv_rope_kv_store",
+    "kerv_silu_mul",
+    "kerv_static_tree_pack",
+    "kerv_tree_embed_pack",
+    "kerv_vision_add_layer_norm",
+    "kerv_vision_bias_gelu",
+    "static_tree_attention",
+    "kerv_static_tree_attention",
+    "install_static_tree_attention",
+    "kerv_value_cache_store",
+    "kerv_verify_accept_control",
+    "register_kerv_ops",
+    "static_tree_attention_reference",
+]

--- a/flagscale/models/kerv/ops/KERVRuntimeOptimization/embodied_ops/kerv_ops.py
+++ b/flagscale/models/kerv/ops/KERVRuntimeOptimization/embodied_ops/kerv_ops.py
@@ -1,0 +1,719 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Inference kernels for KERV's batch-one, short-sequence execution path.
+
+The kernels in this module are intentionally shape guarded.  KERV has many
+small, irregular tensors for which a generic Triton implementation can be
+slower than ATen/cuBLAS.  Unsupported layouts therefore use a transparent
+native implementation instead of silently changing the model semantics.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+try:  # Triton is optional for CPU-only FlagScale installations.
+    import triton
+    import triton.language as tl
+except Exception:  # pragma: no cover - exercised only without Triton.
+    triton = None
+    tl = None
+
+
+_DEF_LIBRARY: torch.library.Library | None = None
+_IMPL_LIBRARY: torch.library.Library | None = None
+_RECORD_PATH: Path | None = None
+_RECORD_ONCE = True
+_RECORDED: set[tuple[object, ...]] = set()
+_BACKEND = "auto"
+_ENABLED_OPERATORS: set[str] | None = None
+# Tiny KERV elementwise/reduction shapes are currently faster through ATen on
+# A100.  Auto mode keeps those paths native; explicit ``backend=triton`` is
+# available for tuning on another backend.
+_AUTO_TRITON_OPERATORS = {
+    "kerv_static_tree_attention": True,
+    # The fused Q/K rotation plus resident K/V write passed the fixed
+    # B=1,Hd=128 short-sequence gate on A100.  Other layouts are rejected by
+    # phase2_ops and fall back to the native implementation.
+    "kerv_rope_kv_store": True,
+}
+
+
+def configure_recording(path: str | None, record: bool, once: bool = True) -> None:
+    """Configure lightweight JSONL hit recording for the public operators."""
+
+    global _RECORD_PATH, _RECORD_ONCE
+    _RECORD_PATH = Path(path) if record and path else None
+    _RECORD_ONCE = bool(once)
+    _RECORDED.clear()
+    if _RECORD_PATH is not None:
+        _RECORD_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _RECORD_PATH.touch(exist_ok=True)
+
+
+def configure_backend(backend: str) -> None:
+    global _BACKEND
+    backend = str(backend).lower()
+    if backend not in {"auto", "triton", "native"}:
+        raise ValueError(f"unsupported KERV embodied backend: {backend}")
+    _BACKEND = backend
+
+
+def configure_enabled_operators(names: set[str] | None) -> None:
+    global _ENABLED_OPERATORS
+    _ENABLED_OPERATORS = None if names is None else set(names)
+
+
+def _use_triton(name: str) -> bool:
+    if _ENABLED_OPERATORS is not None and name not in _ENABLED_OPERATORS:
+        return False
+    if _BACKEND == "native":
+        return False
+    if _BACKEND == "triton":
+        return True
+    return bool(_AUTO_TRITON_OPERATORS.get(name, False))
+
+
+def _record_hit(name: str, *values: torch.Tensor) -> None:
+    if _RECORD_PATH is None:
+        return
+    key = (name, *((tuple(value.shape), str(value.dtype), value.device.type) for value in values))
+    if _RECORD_ONCE and key in _RECORDED:
+        return
+    _RECORDED.add(key)
+    with _RECORD_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "operator": name,
+                    "shapes": [list(value.shape) for value in values],
+                    "dtypes": [str(value.dtype).removeprefix("torch.") for value in values],
+                    "devices": [value.device.type for value in values],
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+
+
+def _is_cuda_contiguous(*values: torch.Tensor) -> bool:
+    return all(value.is_cuda and value.is_contiguous() for value in values)
+
+
+if triton is not None:
+
+    @triton.jit
+    def _silu_mul_kernel(
+        gate_ptr,
+        up_ptr,
+        rows,
+        width: tl.constexpr,
+        stride_gate_row: tl.constexpr,
+        stride_up_row: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        cols = tl.arange(0, BLOCK)
+        mask = cols < width
+        gate = tl.load(gate_ptr + row * stride_gate_row + cols, mask=mask, other=0.0)
+        up = tl.load(up_ptr + row * stride_up_row + cols, mask=mask, other=0.0)
+        gate_f = gate.to(tl.float32)
+        result = gate_f * (1.0 / (1.0 + tl.exp(-gate_f))) * up.to(tl.float32)
+        tl.store(gate_ptr + row * stride_gate_row + cols, result, mask=mask)
+
+    @triton.jit
+    def _add_rms_norm_kernel(
+        hidden_ptr,
+        residual_ptr,
+        weight_ptr,
+        rows,
+        width: tl.constexpr,
+        stride_hidden_row: tl.constexpr,
+        stride_residual_row: tl.constexpr,
+        eps,
+        BLOCK: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        cols = tl.arange(0, BLOCK)
+        mask = cols < width
+        hidden = tl.load(hidden_ptr + row * stride_hidden_row + cols, mask=mask, other=0.0)
+        residual = tl.load(residual_ptr + row * stride_residual_row + cols, mask=mask, other=0.0)
+        value = hidden.to(tl.float32) + residual.to(tl.float32)
+        weight = tl.load(weight_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        mean_square = tl.sum(tl.where(mask, value * value, 0.0), axis=0) / width
+        normalized = value * tl.rsqrt(mean_square + eps) * weight
+        tl.store(hidden_ptr + row * stride_hidden_row + cols, normalized, mask=mask)
+
+    @triton.jit
+    def _verify_accept_control_kernel(
+        logits_ptr,
+        candidates_ptr,
+        best_index_ptr,
+        best_length_ptr,
+        logits_stride_path: tl.constexpr,
+        logits_stride_position: tl.constexpr,
+        candidates_stride_path: tl.constexpr,
+        candidates_stride_position: tl.constexpr,
+        n_paths,
+        n_positions,
+        vocab_size,
+        threshold,
+        token_offset,
+        BLOCK_PATHS: tl.constexpr,
+        BLOCK_VOCAB: tl.constexpr,
+    ):
+        paths = tl.arange(0, BLOCK_PATHS)
+        valid_path = paths < n_paths
+        vocab = tl.arange(0, BLOCK_VOCAB)
+        accepted = tl.zeros((BLOCK_PATHS,), dtype=tl.int32)
+        alive = tl.full((BLOCK_PATHS,), 1, dtype=tl.int32)
+        # KERV's speculative draft is eight tokens.  The runtime falls back
+        # to ATen for longer sequences rather than compiling an unbounded loop.
+        for position in range(0, 32):
+            position_valid = position < n_positions
+            offsets = (
+                paths[:, None] * logits_stride_path
+                + position * logits_stride_position
+                + vocab[None, :]
+            )
+            values = tl.load(
+                logits_ptr + offsets,
+                mask=valid_path[:, None] & (vocab[None, :] < vocab_size) & position_valid,
+                other=-float("inf"),
+            )
+            predicted = tl.argmax(values, axis=1) + token_offset
+            candidate = tl.load(
+                candidates_ptr
+                + paths * candidates_stride_path
+                + (position + 1) * candidates_stride_position,
+                mask=valid_path & position_valid,
+                other=0,
+            )
+            match = tl.abs(candidate - predicted) <= threshold
+            alive = tl.where(position_valid, alive & match.to(tl.int32), alive)
+            accepted += tl.where(position_valid & (alive != 0), 1, 0)
+
+        masked_lengths = tl.where(valid_path, accepted, -1)
+        best_length = tl.max(masked_lengths, axis=0)
+        # Negative path index makes ties deterministic and matches the first
+        # occurrence behavior of torch.argmax.
+        tie_score = tl.where(
+            valid_path & (accepted == best_length), -paths.to(tl.int32), -2147483647
+        )
+        best_index = tl.argmax(tie_score, axis=0)
+        tl.store(best_index_ptr, best_index.to(tl.int64))
+        tl.store(best_length_ptr, best_length.to(tl.int64))
+
+    @triton.jit
+    def _pack_tree_kernel(
+        draft_ptr,
+        kept_ptr,
+        output_ptr,
+        batch,
+        source_nodes,
+        kept_nodes,
+        target_nodes,
+        draft_stride_batch: tl.constexpr,
+        draft_stride_node: tl.constexpr,
+        output_stride_batch: tl.constexpr,
+        output_stride_node: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        linear = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+        total = batch * target_nodes
+        valid = linear < total
+        batch_id = linear // target_nodes
+        node_id = linear - batch_id * target_nodes
+        has_source = node_id < kept_nodes
+        kept = tl.load(kept_ptr + node_id, mask=has_source, other=0)
+        kept = tl.minimum(kept, source_nodes - 1)
+        source = tl.load(
+            draft_ptr + batch_id * draft_stride_batch + kept * draft_stride_node,
+            mask=valid,
+            other=0,
+        )
+        tl.store(
+            output_ptr + batch_id * output_stride_batch + node_id * output_stride_node,
+            source,
+            mask=valid,
+        )
+
+    @triton.jit
+    def _action_argmax_kernel(
+        hidden_ptr,
+        weight_ptr,
+        bias_ptr,
+        output_ptr,
+        rows,
+        hidden_size: tl.constexpr,
+        action_size: tl.constexpr,
+        hidden_stride: tl.constexpr,
+        weight_stride: tl.constexpr,
+        has_bias: tl.constexpr,
+        BLOCK_H: tl.constexpr,
+        BLOCK_V: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        dims = tl.arange(0, BLOCK_H)
+        hidden = tl.load(
+            hidden_ptr + row * hidden_stride + dims,
+            mask=dims < hidden_size,
+            other=0.0,
+        ).to(tl.float32)
+        best_value = tl.full((), -float("inf"), tl.float32)
+        best_index = tl.zeros((), tl.int32)
+        for start in range(0, action_size, BLOCK_V):
+            ids = start + tl.arange(0, BLOCK_V)
+            mask = ids < action_size
+            weights = tl.load(
+                weight_ptr + ids[:, None] * weight_stride + dims[None, :],
+                mask=mask[:, None] & (dims[None, :] < hidden_size),
+                other=0.0,
+            ).to(tl.float32)
+            values = tl.sum(weights * hidden[None, :], axis=1)
+            if has_bias:
+                values += tl.load(bias_ptr + ids, mask=mask, other=0.0).to(tl.float32)
+            local_index = tl.argmax(values, axis=0)
+            local_value = tl.max(values, axis=0)
+            better = local_value > best_value
+            best_value = tl.where(better, local_value, best_value)
+            best_index = tl.where(better, start + local_index, best_index)
+        tl.store(output_ptr + row, best_index.to(tl.int64))
+
+    @triton.jit
+    def _value_cache_store_kernel(
+        source_ptr,
+        destination_ptr,
+        token_count,
+        write_start,
+        heads: tl.constexpr,
+        head_dim: tl.constexpr,
+        source_stride_head: tl.constexpr,
+        source_stride_token: tl.constexpr,
+        source_stride_dim: tl.constexpr,
+        destination_stride_head: tl.constexpr,
+        destination_stride_token: tl.constexpr,
+        destination_stride_dim: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        head = tl.program_id(0)
+        linear = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+        token = linear // head_dim
+        dim = linear - token * head_dim
+        mask = (head < heads) & (token < token_count) & (dim < head_dim)
+        source = head * source_stride_head + token * source_stride_token + dim * source_stride_dim
+        destination = (
+            head * destination_stride_head
+            + (write_start + token) * destination_stride_token
+            + dim * destination_stride_dim
+        )
+        value = tl.load(source_ptr + source, mask=mask, other=0.0)
+        tl.store(destination_ptr + destination, value, mask=mask)
+
+
+def _silu_mul_impl(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+    if gate.shape != up.shape or gate.device != up.device:
+        raise ValueError("gate and up must have the same shape and device")
+    if not gate.is_floating_point():
+        raise TypeError("kerv_silu_mul requires a floating-point tensor")
+    _record_hit("kerv_silu_mul", gate, up)
+    if (
+        _use_triton("kerv_silu_mul")
+        and triton is not None
+        and _is_cuda_contiguous(gate, up)
+        and gate.ndim >= 1
+    ):
+        width = int(gate.shape[-1])
+        if width <= 8192:
+            rows = gate.numel() // width
+            block = min(triton.next_power_of_2(width), 8192)
+            _silu_mul_kernel[(rows,)](
+                gate,
+                up,
+                rows,
+                width,
+                gate.stride(-2) if gate.ndim > 1 else width,
+                up.stride(-2) if up.ndim > 1 else width,
+                BLOCK=block,
+                num_warps=8 if width >= 2048 else 4,
+            )
+            return gate
+    gate.mul_(torch.sigmoid(gate))
+    gate.mul_(up)
+    return gate
+
+
+def _add_rms_norm_impl(
+    hidden: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    if hidden.shape != residual.shape or hidden.device != residual.device:
+        raise ValueError("hidden and residual must have the same shape and device")
+    if weight.ndim != 1 or hidden.shape[-1] != weight.numel():
+        raise ValueError("RMSNorm weight must match the hidden dimension")
+    _record_hit("kerv_add_rms_norm", hidden, residual, weight)
+    if (
+        _use_triton("kerv_add_rms_norm")
+        and triton is not None
+        and _is_cuda_contiguous(hidden, residual, weight)
+    ):
+        width = int(hidden.shape[-1])
+        if width <= 8192:
+            rows = hidden.numel() // width
+            block = min(triton.next_power_of_2(width), 8192)
+            _add_rms_norm_kernel[(rows,)](
+                hidden,
+                residual,
+                weight,
+                rows,
+                width,
+                hidden.stride(-2) if hidden.ndim > 1 else width,
+                residual.stride(-2) if residual.ndim > 1 else width,
+                float(eps),
+                BLOCK=block,
+                num_warps=8 if width >= 2048 else 4,
+            )
+            return hidden
+    hidden.add_(residual)
+    hidden.copy_(F.rms_norm(hidden, (hidden.shape[-1],), weight, float(eps)))
+    return hidden
+
+
+def _verify_accept_impl(
+    logits: torch.Tensor,
+    candidates: torch.Tensor,
+    threshold: float,
+    token_offset: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if logits.ndim != 3 or candidates.ndim != 2:
+        raise ValueError("expected logits[P,S,V] and candidates[P,S]")
+    if logits.shape[:2] != candidates.shape:
+        raise ValueError("logits and candidates path/sequence dimensions must match")
+    candidates_device = candidates.to(logits.device)
+    n_paths, sequence, vocab = map(int, logits.shape)
+    n_positions = sequence - 1
+    if n_paths <= 0 or n_positions <= 0 or vocab <= 0:
+        raise ValueError("Verify-Accept dimensions must be positive")
+    _record_hit("kerv_verify_accept_control", logits, candidates_device)
+    if (
+        _use_triton("kerv_verify_accept_control")
+        and triton is not None
+        and _is_cuda_contiguous(logits, candidates_device)
+        and n_paths <= 128
+        and n_positions <= 32
+        and vocab <= 65536
+    ):
+        block_paths = triton.next_power_of_2(n_paths)
+        block_vocab = triton.next_power_of_2(vocab)
+        # A single-program reduction is useful for the 256-action verifier
+        # head.  Full-vocabulary logits would exceed Triton's maximum tensor
+        # tile, so they intentionally use the native reduction.
+        if block_paths * block_vocab > (1 << 20):
+            block_paths = 0
+            block_vocab = 0
+        if block_paths and block_vocab:
+            best_index = torch.empty((), dtype=torch.long, device=logits.device)
+            best_length = torch.empty((), dtype=torch.long, device=logits.device)
+            _verify_accept_control_kernel[(1,)](
+                logits,
+                candidates_device,
+                best_index,
+                best_length,
+                logits.stride(0),
+                logits.stride(1),
+                candidates_device.stride(0),
+                candidates_device.stride(1),
+                n_paths,
+                n_positions,
+                vocab,
+                float(threshold),
+                int(token_offset),
+                BLOCK_PATHS=block_paths,
+                BLOCK_VOCAB=block_vocab,
+                num_warps=8,
+                num_stages=1,
+            )
+            return best_index, best_length
+
+    predicted = torch.argmax(logits[:, :-1], dim=-1) + int(token_offset)
+    matches = torch.abs(candidates_device[:, 1:] - predicted) <= float(threshold)
+    accepted = torch.cumprod(matches.to(torch.int32), dim=1).sum(dim=1)
+    best = torch.argmax(accepted)
+    return best.to(torch.long), accepted[best].to(torch.long)
+
+
+def _static_tree_pack_impl(
+    draft_tokens: torch.Tensor,
+    kept_indices: torch.Tensor,
+    target_nodes: int,
+) -> torch.Tensor:
+    if draft_tokens.ndim != 2 or kept_indices.ndim != 1:
+        raise ValueError("expected draft_tokens[B,N] and kept_indices[K]")
+    target_nodes = int(target_nodes)
+    kept_nodes = int(kept_indices.numel())
+    if target_nodes < kept_nodes or target_nodes <= 0:
+        raise ValueError("target_nodes must cover the selected tree nodes")
+    if kept_nodes == 0 or draft_tokens.shape[1] <= 0:
+        raise ValueError("tree inputs cannot be empty")
+    _record_hit("kerv_static_tree_pack", draft_tokens, kept_indices)
+    if (
+        _use_triton("kerv_static_tree_pack")
+        and triton is not None
+        and _is_cuda_contiguous(draft_tokens, kept_indices)
+        and kept_indices.dtype in (torch.int32, torch.int64)
+    ):
+        output = torch.empty(
+            (draft_tokens.shape[0], target_nodes),
+            device=draft_tokens.device,
+            dtype=draft_tokens.dtype,
+        )
+        block = 256
+        _pack_tree_kernel[(triton.cdiv(output.numel(), block),)](
+            draft_tokens,
+            kept_indices,
+            output,
+            int(draft_tokens.shape[0]),
+            int(draft_tokens.shape[1]),
+            kept_nodes,
+            target_nodes,
+            draft_tokens.stride(0),
+            draft_tokens.stride(1),
+            output.stride(0),
+            output.stride(1),
+            BLOCK=block,
+            num_warps=4,
+        )
+        return output
+    packed = torch.index_select(draft_tokens, 1, kept_indices.to(draft_tokens.device))
+    if packed.shape[1] == target_nodes:
+        return packed
+    return torch.cat((packed, packed[:, :1].expand(-1, target_nodes - packed.shape[1])), dim=1)
+
+
+def _action_projection_select_impl(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    action_token_offset: int,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if hidden.shape[-1] != weight.shape[-1] or weight.ndim != 2:
+        raise ValueError("hidden and action weight dimensions are incompatible")
+    if action_token_offset < 0:
+        raise ValueError("action_token_offset must be non-negative")
+    selected = weight
+    if bias is not None and bias.numel() != weight.shape[0]:
+        raise ValueError("action bias must match action weight rows")
+    flat = hidden.reshape(-1, hidden.shape[-1])
+    action_size = int(weight.shape[0])
+    _record_hit("kerv_action_projection_select", hidden, weight)
+    if (
+        _use_triton("kerv_action_projection_select")
+        and triton is not None
+        and _is_cuda_contiguous(flat, weight)
+        and (bias is None or bias.is_cuda and bias.is_contiguous())
+        and action_size <= 512
+        and hidden.shape[-1] <= 8192
+    ):
+        output = torch.empty((flat.shape[0],), dtype=torch.long, device=hidden.device)
+        block_h = min(triton.next_power_of_2(int(hidden.shape[-1])), 8192)
+        block_v = min(triton.next_power_of_2(action_size), 512)
+        dummy_bias = bias if bias is not None else weight.new_empty((1,))
+        _action_argmax_kernel[(flat.shape[0],)](
+            flat,
+            selected,
+            dummy_bias,
+            output,
+            int(flat.shape[0]),
+            int(hidden.shape[-1]),
+            action_size,
+            flat.stride(0),
+            selected.stride(0),
+            bias is not None,
+            BLOCK_H=block_h,
+            BLOCK_V=block_v,
+            num_warps=8,
+            num_stages=1,
+        )
+        return output.reshape(hidden.shape[:-1]) + int(action_token_offset)
+    logits = F.linear(flat, selected, bias)
+    return logits.argmax(dim=-1).reshape(hidden.shape[:-1]) + int(action_token_offset)
+
+
+def _value_cache_store_impl(
+    destination: torch.Tensor,
+    source: torch.Tensor,
+    write_start: int,
+) -> torch.Tensor:
+    if source.ndim != 4 or destination.ndim != 4:
+        raise ValueError("value cache tensors must use [B,H,T,D]")
+    if source.shape[0] != 1 or destination.shape[0] != 1:
+        raise ValueError("KERV value cache store currently supports batch=1")
+    if source.shape[1] != destination.shape[1] or source.shape[-1] != destination.shape[-1]:
+        raise ValueError("source and destination cache layouts are incompatible")
+    token_count = int(source.shape[-2])
+    write_start = int(write_start)
+    if write_start < 0 or write_start + token_count > destination.shape[-2]:
+        raise ValueError("value cache write exceeds destination capacity")
+    _record_hit("kerv_value_cache_store", destination, source)
+    if (
+        _use_triton("kerv_value_cache_store")
+        and triton is not None
+        and _is_cuda_contiguous(source, destination)
+        and source.stride(-1) == destination.stride(-1) == 1
+    ):
+        block = 1024
+        _value_cache_store_kernel[
+            (source.shape[1], triton.cdiv(token_count * source.shape[-1], block))
+        ](
+            source,
+            destination,
+            token_count,
+            write_start,
+            source.shape[1],
+            source.shape[-1],
+            source.stride(1),
+            source.stride(2),
+            source.stride(3),
+            destination.stride(1),
+            destination.stride(2),
+            destination.stride(3),
+            BLOCK=block,
+            num_warps=4,
+            num_stages=1,
+        )
+        return destination
+    destination[..., write_start : write_start + token_count, :].copy_(source)
+    return destination
+
+
+def _kv_commit_impl(
+    destination: torch.Tensor,
+    source: torch.Tensor,
+    write_start: int,
+) -> torch.Tensor:
+    if source.ndim != destination.ndim or source.shape[-1] != destination.shape[-1]:
+        raise ValueError("KV commit tensors are incompatible")
+    end = int(write_start) + int(source.shape[-2])
+    if int(write_start) < 0 or end > destination.shape[-2]:
+        raise ValueError("KV commit exceeds destination capacity")
+    _record_hit("kerv_kv_commit", destination, source)
+    destination[..., int(write_start) : end, :].copy_(source)
+    return destination
+
+
+def register_kerv_ops() -> None:
+    """Register all public operators once under ``torch.ops.flagos_embodied``."""
+
+    global _DEF_LIBRARY, _IMPL_LIBRARY
+    if _DEF_LIBRARY is not None:
+        return
+    _DEF_LIBRARY = torch.library.Library("flagos_embodied", "DEF")
+    definitions = (
+        "kerv_silu_mul(Tensor(a!) gate, Tensor up) -> Tensor(a!)",
+        "kerv_add_rms_norm(Tensor(a!) hidden, Tensor residual, Tensor weight, float eps) -> Tensor(a!)",
+        "kerv_verify_accept_control(Tensor logits, Tensor candidates, float threshold, int token_offset) -> (Tensor, Tensor)",
+        "kerv_static_tree_pack(Tensor draft_tokens, Tensor kept_indices, int target_nodes) -> Tensor",
+        "kerv_action_projection_select(Tensor hidden, Tensor weight, int action_token_offset, Tensor? bias=None) -> Tensor",
+        "kerv_value_cache_store(Tensor(a!) destination, Tensor source, int write_start) -> Tensor(a!)",
+        "kerv_kv_commit(Tensor(a!) destination, Tensor source, int write_start) -> Tensor(a!)",
+    )
+    for definition in definitions:
+        _DEF_LIBRARY.define(definition)
+    _IMPL_LIBRARY = torch.library.Library("flagos_embodied", "IMPL", "CompositeExplicitAutograd")
+    _IMPL_LIBRARY.impl("kerv_silu_mul", _silu_mul_impl)
+    _IMPL_LIBRARY.impl("kerv_add_rms_norm", _add_rms_norm_impl)
+    _IMPL_LIBRARY.impl("kerv_verify_accept_control", _verify_accept_impl)
+    _IMPL_LIBRARY.impl("kerv_static_tree_pack", _static_tree_pack_impl)
+    _IMPL_LIBRARY.impl("kerv_action_projection_select", _action_projection_select_impl)
+    _IMPL_LIBRARY.impl("kerv_value_cache_store", _value_cache_store_impl)
+    _IMPL_LIBRARY.impl("kerv_kv_commit", _kv_commit_impl)
+
+    # The second-stage KERV operators live in a separate module so that the
+    # stable first-stage ABI remains importable on CPU-only installations.
+    # Register them only after the base namespace has been defined; the
+    # ``FRAGMENT`` library used by phase2_ops then safely extends it.
+    from .phase2_ops import register_phase2_ops
+
+    register_phase2_ops()
+
+
+register_kerv_ops()
+
+
+def kerv_silu_mul(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+    return torch.ops.flagos_embodied.kerv_silu_mul(gate, up)
+
+
+def kerv_add_rms_norm(
+    hidden: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    return torch.ops.flagos_embodied.kerv_add_rms_norm(hidden, residual, weight, float(eps))
+
+
+def kerv_verify_accept_control(
+    logits: torch.Tensor,
+    candidates: torch.Tensor,
+    threshold: float,
+    token_offset: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops.flagos_embodied.kerv_verify_accept_control(
+        logits, candidates, float(threshold), int(token_offset)
+    )
+
+
+def kerv_static_tree_pack(
+    draft_tokens: torch.Tensor,
+    kept_indices: torch.Tensor,
+    target_nodes: int,
+) -> torch.Tensor:
+    return torch.ops.flagos_embodied.kerv_static_tree_pack(
+        draft_tokens, kept_indices, int(target_nodes)
+    )
+
+
+def kerv_action_projection_select(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    action_token_offset: int,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return torch.ops.flagos_embodied.kerv_action_projection_select(
+        hidden, weight, int(action_token_offset), bias
+    )
+
+
+def kerv_value_cache_store(
+    destination: torch.Tensor,
+    source: torch.Tensor,
+    write_start: int,
+) -> torch.Tensor:
+    return torch.ops.flagos_embodied.kerv_value_cache_store(destination, source, int(write_start))
+
+
+def kerv_kv_commit(
+    destination: torch.Tensor,
+    source: torch.Tensor,
+    write_start: int,
+) -> torch.Tensor:
+    return torch.ops.flagos_embodied.kerv_kv_commit(destination, source, int(write_start))

--- a/flagscale/models/kerv/ops/KERVRuntimeOptimization/embodied_ops/operator_manifest.json
+++ b/flagscale/models/kerv/ops/KERVRuntimeOptimization/embodied_ops/operator_manifest.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 2,
+  "namespace": "flagos_embodied",
+  "target_workload": "KERV batch-one speculative verification",
+  "operators": [
+    {"name": "kerv_silu_mul", "kind": "elementwise_fusion", "default_backend": "native"},
+    {"name": "kerv_add_rms_norm", "kind": "residual_norm_fusion", "default_backend": "native"},
+    {"name": "kerv_verify_accept_control", "kind": "verification_reduction", "default_backend": "native"},
+    {"name": "kerv_static_tree_pack", "kind": "resident_template_pack", "default_backend": "native"},
+    {"name": "kerv_static_tree_attention", "kind": "prefix_ancestor_attention", "default_backend": "triton-auto"},
+    {"name": "kerv_action_projection_select", "kind": "action_vocab_projection", "default_backend": "native"},
+    {"name": "kerv_value_cache_store", "kind": "value_cache_write", "default_backend": "native"},
+    {"name": "kerv_kv_commit", "kind": "resident_cache_commit", "default_backend": "native"},
+    {"name": "kerv_tree_embed_pack", "kind": "tree_embedding_pack", "default_backend": "native"},
+    {"name": "kerv_rope_kv_store", "kind": "rope_and_resident_kv_write", "default_backend": "triton-auto"},
+    {"name": "kerv_action_verify_accept", "kind": "action_projection_and_accept", "default_backend": "native"},
+    {"name": "kerv_draft_action_topk", "kind": "action_projection_topk", "default_backend": "native"},
+    {"name": "kerv_kv_accept_commit", "kind": "accepted_path_commit", "default_backend": "native"},
+    {"name": "kerv_vision_add_layer_norm", "kind": "vision_residual_norm_fusion", "default_backend": "native"},
+    {"name": "kerv_vision_bias_gelu", "kind": "vision_bias_activation_fusion", "default_backend": "native"},
+    {"name": "kerv_o_proj_residual_rms_norm", "kind": "experimental_gemm_epilogue", "default_backend": "opt-in"},
+    {"name": "kerv_down_proj_residual_rms_norm", "kind": "experimental_gemm_epilogue", "default_backend": "opt-in"},
+    {"name": "kerv_logical_kv_commit", "kind": "experimental_logical_cache_commit", "default_backend": "opt-in"}
+  ],
+  "selection_policy": "auto selects only measured fixed-shape kernels; all other inputs use the exact platform-native implementation. Mainline phase-two interfaces are opt-in by include list and experimental interfaces are never enabled implicitly.",
+  "performance_gate": {"min_local_speedup": 1.05, "target_e2e_speedup": 1.08},
+  "supported_profile": {"batch": 1, "dtype": ["float16", "bfloat16"], "head_dim": 128, "verify_paths": [48, 49], "tree_depth": [4, 5, 8]}
+}

--- a/flagscale/models/kerv/ops/KERVRuntimeOptimization/embodied_ops/phase2_ops.py
+++ b/flagscale/models/kerv/ops/KERVRuntimeOptimization/embodied_ops/phase2_ops.py
@@ -1,0 +1,754 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Second-stage KERV operator paths.
+
+These operators deliberately keep the model's exact control semantics in the
+native implementation.  Triton is used only for layouts that are fixed by the
+KERV runtime (batch one, contiguous tensors and short verification trees); all
+other inputs go through the reference path.  The public schemas are small
+enough to be reused by the KERV bridge and by downstream FlagOS backends.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+from .kerv_ops import _is_cuda_contiguous, _record_hit, _use_triton
+
+try:  # Triton is optional for CPU-only installations.
+    import triton
+    import triton.language as tl
+except Exception:  # pragma: no cover - CPU-only environments.
+    triton = None
+    tl = None
+
+
+_DEF_LIBRARY: torch.library.Library | None = None
+_IMPL_LIBRARY: torch.library.Library | None = None
+
+
+if triton is not None:
+
+    @triton.jit
+    def _tree_embed_pack_kernel(
+        token_ptr,
+        kept_ptr,
+        weight_ptr,
+        output_ptr,
+        source_nodes,
+        kept_nodes,
+        target_nodes,
+        hidden_size: tl.constexpr,
+        token_stride_batch: tl.constexpr,
+        token_stride_node: tl.constexpr,
+        kept_stride: tl.constexpr,
+        weight_stride: tl.constexpr,
+        output_stride_batch: tl.constexpr,
+        output_stride_node: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        linear = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+        total = target_nodes * hidden_size
+        valid = linear < total
+        node = linear // hidden_size
+        dim = linear - node * hidden_size
+        source_slot = tl.load(
+            kept_ptr + tl.where(node < kept_nodes, node, 0) * kept_stride,
+            mask=valid & (kept_nodes > 0),
+            other=0,
+        )
+        source_slot = tl.minimum(source_slot, source_nodes - 1)
+        token_id = tl.load(
+            token_ptr + source_slot * token_stride_node,
+            mask=valid & (source_nodes > 0),
+            other=0,
+        )
+        value = tl.load(
+            weight_ptr + token_id * weight_stride + dim,
+            mask=valid & (dim < hidden_size),
+            other=0.0,
+        )
+        tl.store(
+            output_ptr + node * output_stride_node + dim,
+            value,
+            mask=valid,
+        )
+
+    @triton.jit
+    def _rope_kv_store_kernel(
+        query_ptr,
+        key_ptr,
+        value_ptr,
+        cos_ptr,
+        sin_ptr,
+        query_out_ptr,
+        key_cache_ptr,
+        value_cache_ptr,
+        sequence,
+        q_heads: tl.constexpr,
+        kv_heads: tl.constexpr,
+        head_dim: tl.constexpr,
+        write_start,
+        q_stride_h: tl.constexpr,
+        q_stride_s: tl.constexpr,
+        k_stride_h: tl.constexpr,
+        k_stride_s: tl.constexpr,
+        v_stride_h: tl.constexpr,
+        v_stride_s: tl.constexpr,
+        oq_stride_h: tl.constexpr,
+        oq_stride_s: tl.constexpr,
+        cache_stride_h: tl.constexpr,
+        cache_stride_s: tl.constexpr,
+        cos_stride_s: tl.constexpr,
+        sin_stride_s: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        token = tl.program_id(0)
+        head = tl.program_id(1)
+        dims = tl.arange(0, BLOCK)
+        valid_dim = dims < head_dim
+        valid_token = token < sequence
+        half = head_dim // 2
+        rotated = (dims + half) % head_dim
+        cos = tl.load(
+            cos_ptr + token * cos_stride_s + dims,
+            mask=valid_token & valid_dim,
+            other=0.0,
+        )
+        sin = tl.load(
+            sin_ptr + token * sin_stride_s + dims,
+            mask=valid_token & valid_dim,
+            other=0.0,
+        )
+        sin = tl.where(dims < half, -sin, sin)
+        q_valid = valid_token & valid_dim & (head < q_heads)
+        q_base = head * q_stride_h + token * q_stride_s
+        q = tl.load(query_ptr + q_base + dims, mask=q_valid, other=0.0)
+        q_rot = tl.load(query_ptr + q_base + rotated, mask=q_valid, other=0.0)
+        q_result = q * cos + q_rot * sin
+        q_out_base = head * oq_stride_h + token * oq_stride_s
+        tl.store(query_out_ptr + q_out_base + dims, q_result, mask=q_valid)
+
+        kv_valid = valid_token & valid_dim & (head < kv_heads)
+        k_base = head * k_stride_h + token * k_stride_s
+        k = tl.load(key_ptr + k_base + dims, mask=kv_valid, other=0.0)
+        k_rot = tl.load(key_ptr + k_base + rotated, mask=kv_valid, other=0.0)
+        k_result = k * cos + k_rot * sin
+        cache_base = head * cache_stride_h + (write_start + token) * cache_stride_s
+        tl.store(key_cache_ptr + cache_base + dims, k_result, mask=kv_valid)
+        v_base = head * v_stride_h + token * v_stride_s
+        value = tl.load(value_ptr + v_base + dims, mask=kv_valid, other=0.0)
+        tl.store(value_cache_ptr + cache_base + dims, value, mask=kv_valid)
+
+    @triton.jit
+    def _vision_add_layer_norm_kernel(
+        hidden_ptr,
+        residual_ptr,
+        weight_ptr,
+        bias_ptr,
+        output_ptr,
+        rows,
+        width: tl.constexpr,
+        eps,
+        has_bias: tl.constexpr,
+        hidden_stride: tl.constexpr,
+        residual_stride: tl.constexpr,
+        output_stride: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        cols = tl.arange(0, BLOCK)
+        mask = (row < rows) & (cols < width)
+        value = tl.load(hidden_ptr + row * hidden_stride + cols, mask=mask, other=0.0).to(
+            tl.float32
+        )
+        value += tl.load(residual_ptr + row * residual_stride + cols, mask=mask, other=0.0).to(
+            tl.float32
+        )
+        mean = tl.sum(tl.where(mask, value, 0.0), axis=0) / width
+        centered = value - mean
+        variance = tl.sum(tl.where(mask, centered * centered, 0.0), axis=0) / width
+        weight = tl.load(weight_ptr + cols, mask=cols < width, other=1.0).to(tl.float32)
+        result = centered * tl.rsqrt(variance + eps) * weight
+        if has_bias:
+            result += tl.load(bias_ptr + cols, mask=cols < width, other=0.0).to(tl.float32)
+        tl.store(output_ptr + row * output_stride + cols, result, mask=mask)
+
+    @triton.jit
+    def _vision_bias_gelu_kernel(
+        input_ptr,
+        bias_ptr,
+        output_ptr,
+        rows,
+        width: tl.constexpr,
+        input_stride: tl.constexpr,
+        output_stride: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        cols = tl.arange(0, BLOCK)
+        mask = (row < rows) & (cols < width)
+        value = tl.load(input_ptr + row * input_stride + cols, mask=mask, other=0.0).to(tl.float32)
+        value += tl.load(bias_ptr + cols, mask=cols < width, other=0.0).to(tl.float32)
+        # Exact GELU is used by the vision towers covered by this adapter.
+        inv_sqrt2 = 0.7071067811865476
+        result = value * 0.5 * (1.0 + tl.erf(value * inv_sqrt2))
+        tl.store(output_ptr + row * output_stride + cols, result, mask=mask)
+
+    @triton.jit
+    def _kv_accept_commit_kernel(
+        storage_ptr,
+        indices_ptr,
+        previous_length,
+        accepted,
+        row_stride: tl.constexpr,
+        capacity: tl.constexpr,
+        head_dim: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        offsets = tl.arange(0, BLOCK)
+        valid = offsets < accepted * head_dim
+        accepted_index = offsets // head_dim
+        feature = offsets - accepted_index * head_dim
+        source_node = tl.load(indices_ptr + accepted_index, mask=valid, other=0)
+        base = row * row_stride
+        source = base + (previous_length + source_node) * head_dim + feature
+        values = tl.load(storage_ptr + source, mask=valid, other=0.0)
+        destination = base + (previous_length + accepted_index) * head_dim + feature
+        tl.store(storage_ptr + destination, values, mask=valid)
+
+
+def _check_matrix(hidden: torch.Tensor, weight: torch.Tensor) -> tuple[torch.Tensor, int, int]:
+    if hidden.ndim < 2 or weight.ndim != 2 or hidden.shape[-1] != weight.shape[-1]:
+        raise ValueError("hidden and weight dimensions are incompatible")
+    flat = hidden.reshape(-1, hidden.shape[-1])
+    return flat, int(flat.shape[0]), int(flat.shape[1])
+
+
+def _tree_embed_pack_impl(
+    draft_tokens: torch.Tensor,
+    kept_indices: torch.Tensor,
+    embedding_weight: torch.Tensor,
+    target_nodes: int,
+) -> torch.Tensor:
+    if draft_tokens.ndim != 2 or kept_indices.ndim != 1 or embedding_weight.ndim != 2:
+        raise ValueError("tree embed pack expects [B,N], [M] and [V,H] tensors")
+    target_nodes = int(target_nodes)
+    if draft_tokens.shape[0] != 1 or target_nodes <= 0 or kept_indices.numel() <= 0:
+        raise ValueError("tree embed pack currently requires batch=1 and non-empty indices")
+    if target_nodes < kept_indices.numel():
+        raise ValueError("target_nodes must cover all kept nodes")
+    if draft_tokens.device != embedding_weight.device or draft_tokens.device != kept_indices.device:
+        raise ValueError("tree embed pack tensors must share a device")
+    # Avoid a host synchronization on every CUDA tree replay.  Production
+    # templates are validated when they are built; retain the range check for
+    # CPU/debug calls where it is useful to report a malformed template.
+    if not kept_indices.is_cuda:
+        if int(kept_indices.max()) >= draft_tokens.shape[1] or int(kept_indices.min()) < 0:
+            raise ValueError("kept_indices is outside draft_tokens")
+    _record_hit("kerv_tree_embed_pack", draft_tokens, kept_indices, embedding_weight)
+    # A static verifier template normally presents the already ordered full
+    # node list. Avoid an otherwise redundant index_select in that common
+    # case; padded/gathered templates still use the general path below.
+    if (
+        target_nodes == int(draft_tokens.shape[1])
+        and kept_indices.numel() == draft_tokens.shape[1]
+        and not kept_indices.is_cuda
+        and torch.equal(
+            kept_indices,
+            torch.arange(
+                draft_tokens.shape[1],
+                device=kept_indices.device,
+                dtype=kept_indices.dtype,
+            ),
+        )
+    ):
+        return F.embedding(draft_tokens, embedding_weight)
+    output = torch.empty(
+        (1, target_nodes, embedding_weight.shape[-1]),
+        device=embedding_weight.device,
+        dtype=embedding_weight.dtype,
+    )
+    if (
+        _use_triton("kerv_tree_embed_pack")
+        and triton is not None
+        and _is_cuda_contiguous(draft_tokens, kept_indices, embedding_weight, output)
+        and embedding_weight.shape[-1] <= 8192
+    ):
+        block = min(triton.next_power_of_2(int(embedding_weight.shape[-1])), 8192)
+        _tree_embed_pack_kernel[(triton.cdiv(output.numel(), block),)](
+            draft_tokens,
+            kept_indices,
+            embedding_weight,
+            output,
+            int(draft_tokens.shape[1]),
+            int(kept_indices.numel()),
+            target_nodes,
+            int(embedding_weight.shape[-1]),
+            draft_tokens.stride(0),
+            draft_tokens.stride(1),
+            kept_indices.stride(0),
+            embedding_weight.stride(0),
+            output.stride(0),
+            output.stride(1),
+            BLOCK=block,
+            num_warps=4,
+        )
+        return output
+    selected = draft_tokens.index_select(1, kept_indices)
+    if selected.shape[1] < target_nodes:
+        selected = torch.cat(
+            (selected, selected[:, :1].expand(-1, target_nodes - selected.shape[1])),
+            dim=1,
+        )
+    return F.embedding(selected, embedding_weight)
+
+
+def _rope_kv_store_impl(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    write_start: int,
+) -> torch.Tensor:
+    if query.ndim != 4 or key.ndim != 4 or value.ndim != 4:
+        raise ValueError("RoPE KV store expects [B,H,S,D] tensors")
+    if query.shape[0] != key.shape[0] or key.shape != value.shape:
+        raise ValueError("Q/K/V layouts are incompatible")
+    if query.shape[-1] % 2 or cos.shape != sin.shape:
+        raise ValueError("RoPE tables must have matching even-width shapes")
+    if query.shape[0] != 1 or query.shape[-1] != 128:
+        raise ValueError("KERV RoPE KV store currently supports batch=1, head_dim=128")
+    if key_cache.ndim != 4 or value_cache.shape != key_cache.shape:
+        raise ValueError("resident K/V destinations are incompatible")
+    if key_cache.shape[1] != key.shape[1] or key_cache.shape[-1] != key.shape[-1]:
+        raise ValueError("resident K/V head dimensions are incompatible")
+    sequence = int(query.shape[2])
+    write_start = int(write_start)
+    if write_start < 0 or write_start + sequence > key_cache.shape[2]:
+        raise ValueError("resident K/V write exceeds capacity")
+    _record_hit("kerv_rope_kv_store", query, key, value, key_cache, value_cache)
+    q_out = torch.empty_like(query)
+    direct_tables = (
+        cos.ndim == 3
+        and sin.ndim == 3
+        and cos.shape == (1, sequence, query.shape[-1])
+        and sin.shape == cos.shape
+    )
+    if (
+        _use_triton("kerv_rope_kv_store")
+        and triton is not None
+        and direct_tables
+        and position_ids.numel() == 0
+        and all(
+            tensor.is_cuda and tensor.stride(-1) == 1
+            for tensor in (query, key, value, cos, sin, q_out)
+        )
+        and key_cache.is_cuda
+        and value_cache.is_cuda
+        and key_cache.stride(-1) == value_cache.stride(-1) == 1
+    ):
+        block = triton.next_power_of_2(int(query.shape[-1]))
+        _rope_kv_store_kernel[(sequence, max(int(query.shape[1]), int(key.shape[1])))](
+            query,
+            key,
+            value,
+            cos,
+            sin,
+            q_out,
+            key_cache,
+            value_cache,
+            sequence,
+            int(query.shape[1]),
+            int(key.shape[1]),
+            int(query.shape[-1]),
+            write_start,
+            query.stride(1),
+            query.stride(2),
+            key.stride(1),
+            key.stride(2),
+            value.stride(1),
+            value.stride(2),
+            q_out.stride(1),
+            q_out.stride(2),
+            key_cache.stride(1),
+            key_cache.stride(2),
+            cos.stride(1),
+            sin.stride(1),
+            BLOCK=block,
+            num_warps=1,
+        )
+        return q_out
+    if position_ids.numel() > 0:
+        if position_ids.shape != (1, sequence):
+            raise ValueError("position_ids must be [1,S]")
+        cos_selected = (
+            cos.reshape(-1, cos.shape[-1])
+            .index_select(0, position_ids.reshape(-1))
+            .reshape(1, sequence, -1)
+        )
+        sin_selected = (
+            sin.reshape(-1, sin.shape[-1])
+            .index_select(0, position_ids.reshape(-1))
+            .reshape(1, sequence, -1)
+        )
+    else:
+        cos_selected, sin_selected = cos, sin
+    q_cos = cos_selected.unsqueeze(1)
+    q_sin = sin_selected.unsqueeze(1)
+    half = query.shape[-1] // 2
+
+    def rotate(x: torch.Tensor) -> torch.Tensor:
+        return torch.cat((-x[..., half:], x[..., :half]), dim=-1)
+
+    q_out.copy_(query * q_cos + rotate(query) * q_sin)
+    key_out = key * q_cos + rotate(key) * q_sin
+    key_cache[..., write_start : write_start + sequence, :].copy_(key_out)
+    value_cache[..., write_start : write_start + sequence, :].copy_(value)
+    return q_out
+
+
+def _action_verify_accept_impl(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    candidates: torch.Tensor,
+    threshold: float,
+    token_offset: int,
+    bias: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    flat, _, _ = _check_matrix(hidden, weight)
+    if candidates.ndim != 2 or candidates.numel() == 0:
+        raise ValueError("candidates must be a non-empty [paths, sequence] tensor")
+    if flat.shape[0] != candidates.numel():
+        raise ValueError("hidden rows must equal candidates.numel()")
+    if int(weight.shape[0]) <= 0:
+        raise ValueError("action vocabulary cannot be empty")
+    _record_hit("kerv_action_verify_accept", hidden, weight, candidates)
+    logits = F.linear(flat, weight, bias).reshape(*candidates.shape, int(weight.shape[0]))
+    predicted = logits.argmax(dim=-1).to(torch.long) + int(token_offset)
+    matches = (predicted[:, :-1] - candidates[:, 1:]).abs() <= float(threshold)
+    accepted = torch.cumprod(matches.to(torch.int32), dim=1).sum(dim=1)
+    best = accepted.argmax().to(torch.long)
+    length = accepted[best].to(torch.long)
+    next_position = length.clamp_max(int(predicted.shape[1] - 1))
+    next_token = predicted[best, next_position]
+    return best, length, next_token
+
+
+def _draft_action_topk_impl(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    action_token_offset: int,
+    k: int,
+    bias: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    flat, _, _ = _check_matrix(hidden, weight)
+    k = int(k)
+    if k <= 0 or k > weight.shape[0]:
+        raise ValueError("invalid action Top-K")
+    _record_hit("kerv_draft_action_topk", hidden, weight)
+    logits = F.linear(flat, weight, bias)
+    log_probs = F.log_softmax(logits.float(), dim=-1)
+    # Stable sorting gives the deterministic lower-token-id tie rule required
+    # for reproducible tree templates.  The action vocabulary is only 256
+    # rows in KERV, so this reduction is cheaper than the full model LM head;
+    # replacing it with an unconstrained TopK would make equal BF16 scores
+    # reorder candidates across backends.
+    values, indices = torch.sort(log_probs, dim=-1, descending=True, stable=True)
+    return (
+        values[..., :k].to(logits.dtype),
+        indices[..., :k].to(torch.long) + int(action_token_offset),
+    )
+
+
+def _kv_accept_commit_impl(
+    storage: torch.Tensor,
+    tree_indices: torch.Tensor,
+    previous_length: int,
+    scratch: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if storage.ndim != 6 or tree_indices.ndim != 1 or not storage.is_contiguous():
+        raise ValueError(
+            "KV accept commit expects contiguous [L,2,B,H,T,D] storage and [A] indices"
+        )
+    previous_length = int(previous_length)
+    if previous_length < 0 or tree_indices.numel() == 0:
+        raise ValueError("invalid KV commit arguments")
+    accepted = int(tree_indices.numel())
+    if previous_length + accepted > storage.shape[-2]:
+        raise ValueError("KV accept commit exceeds storage capacity")
+    _record_hit("kerv_kv_accept_commit", storage, tree_indices)
+    # The source and destination ranges can overlap when a tree path reuses a
+    # prefix node.  The native path takes a clone and is therefore the exact
+    # default.  Only use the one-pass kernel for a provably disjoint mapping;
+    # this keeps explicit Triton benchmarking from changing cache semantics.
+    source_indices = tree_indices.to(device=storage.device, dtype=torch.long)
+    if scratch is not None:
+        expected = (*storage.shape[:-2], accepted, storage.shape[-1])
+        if (
+            tuple(scratch.shape) != expected
+            or scratch.device != storage.device
+            or scratch.dtype != storage.dtype
+        ):
+            raise ValueError("KV commit scratch buffer has an incompatible layout")
+        absolute_indices = source_indices + previous_length
+        torch.index_select(storage, -2, absolute_indices, out=scratch)
+        storage[..., previous_length : previous_length + accepted, :].copy_(scratch)
+        return storage
+    disjoint = bool(torch.all(source_indices >= accepted).item())
+    if (
+        _use_triton("kerv_kv_accept_commit")
+        and triton is not None
+        and _is_cuda_contiguous(storage, tree_indices)
+        and accepted * storage.shape[-1] <= 8192
+        and disjoint
+    ):
+        row_count = int(storage.numel() // (storage.shape[-2] * storage.shape[-1]))
+        block = triton.next_power_of_2(accepted * int(storage.shape[-1]))
+        _kv_accept_commit_kernel[(row_count,)](
+            storage,
+            tree_indices.to(dtype=torch.long),
+            previous_length,
+            accepted,
+            int(storage.shape[-2] * storage.shape[-1]),
+            int(storage.shape[-2]),
+            int(storage.shape[-1]),
+            BLOCK=block,
+            num_warps=4,
+        )
+        return storage
+    # Advanced indexing already materialises a gather result.  Cloning it
+    # again doubled the temporary HBM traffic on every accepted branch; the
+    # destination copy below consumes the gathered tensor directly.
+    source = storage[..., previous_length + tree_indices, :]
+    storage[..., previous_length : previous_length + accepted, :].copy_(source)
+    return storage
+
+
+def _vision_add_layer_norm_impl(
+    hidden: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    eps: float,
+) -> torch.Tensor:
+    if hidden.shape != residual.shape or hidden.shape[-1] != weight.numel():
+        raise ValueError("vision Add-LayerNorm shapes are incompatible")
+    _record_hit("kerv_vision_add_layer_norm", hidden, residual, weight)
+    output = torch.empty_like(hidden)
+    width = int(hidden.shape[-1])
+    if (
+        _use_triton("kerv_vision_add_layer_norm")
+        and triton is not None
+        and _is_cuda_contiguous(hidden, residual, weight, output)
+        and (bias is None or _is_cuda_contiguous(bias))
+        and width <= 8192
+    ):
+        block = min(triton.next_power_of_2(width), 8192)
+        _vision_add_layer_norm_kernel[(hidden.numel() // width,)](
+            hidden,
+            residual,
+            weight,
+            bias if bias is not None else weight.new_empty((1,)),
+            output,
+            hidden.numel() // width,
+            width,
+            float(eps),
+            bias is not None,
+            hidden.stride(-2) if hidden.ndim > 1 else width,
+            residual.stride(-2) if residual.ndim > 1 else width,
+            output.stride(-2) if output.ndim > 1 else width,
+            BLOCK=block,
+            num_warps=8 if width >= 2048 else 4,
+        )
+        return output
+    return F.layer_norm(hidden + residual, (width,), weight, bias, float(eps))
+
+
+def _vision_bias_gelu_impl(
+    hidden: torch.Tensor,
+    bias: torch.Tensor,
+) -> torch.Tensor:
+    if hidden.shape[-1] != bias.numel():
+        raise ValueError("vision Bias-GELU width mismatch")
+    _record_hit("kerv_vision_bias_gelu", hidden, bias)
+    output = torch.empty_like(hidden)
+    width = int(hidden.shape[-1])
+    if (
+        _use_triton("kerv_vision_bias_gelu")
+        and triton is not None
+        and _is_cuda_contiguous(hidden, bias, output)
+        and width <= 8192
+    ):
+        block = min(triton.next_power_of_2(width), 8192)
+        _vision_bias_gelu_kernel[(hidden.numel() // width,)](
+            hidden,
+            bias,
+            output,
+            hidden.numel() // width,
+            width,
+            hidden.stride(-2) if hidden.ndim > 1 else width,
+            output.stride(-2) if output.ndim > 1 else width,
+            BLOCK=block,
+            num_warps=8 if width >= 2048 else 4,
+        )
+        return output
+    return F.gelu(hidden + bias, approximate="none")
+
+
+def _o_proj_residual_rms_norm_impl(
+    hidden: torch.Tensor,
+    weight_proj: torch.Tensor,
+    residual: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    _record_hit("kerv_o_proj_residual_rms_norm", hidden, weight_proj, residual, norm_weight)
+    projected = F.linear(hidden, weight_proj, bias)
+    return F.rms_norm(projected + residual, (projected.shape[-1],), norm_weight, float(eps))
+
+
+def _down_proj_residual_rms_norm_impl(
+    hidden: torch.Tensor,
+    weight_proj: torch.Tensor,
+    residual: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    _record_hit("kerv_down_proj_residual_rms_norm", hidden, weight_proj, residual, norm_weight)
+    projected = F.linear(hidden, weight_proj, bias)
+    return F.rms_norm(projected + residual, (projected.shape[-1],), norm_weight, float(eps))
+
+
+def _logical_kv_commit_impl(
+    logical_map: torch.Tensor,
+    tree_indices: torch.Tensor,
+    previous_length: int,
+) -> torch.Tensor:
+    if logical_map.ndim != 1 or tree_indices.ndim != 1:
+        raise ValueError("logical KV commit expects one-dimensional maps")
+    previous_length = int(previous_length)
+    end = previous_length + int(tree_indices.numel())
+    if previous_length < 0 or end > logical_map.numel():
+        raise ValueError("logical KV commit exceeds map capacity")
+    _record_hit("kerv_logical_kv_commit", logical_map, tree_indices)
+    logical_map[previous_length:end].copy_(tree_indices.to(logical_map.device, logical_map.dtype))
+    return logical_map
+
+
+def register_phase2_ops() -> None:
+    """Register second-stage operators under the existing namespace."""
+
+    global _DEF_LIBRARY, _IMPL_LIBRARY
+    if _DEF_LIBRARY is not None:
+        return
+    _DEF_LIBRARY = torch.library.Library("flagos_embodied", "FRAGMENT")
+    definitions = (
+        "kerv_tree_embed_pack(Tensor draft_tokens, Tensor kept_indices, Tensor embedding_weight, int target_nodes) -> Tensor",
+        "kerv_rope_kv_store(Tensor query, Tensor key, Tensor value, Tensor cos, Tensor sin, Tensor position_ids, Tensor(a!) key_cache, Tensor(b!) value_cache, int write_start) -> Tensor",
+        "kerv_action_verify_accept(Tensor hidden, Tensor weight, Tensor candidates, float threshold, int token_offset, Tensor? bias=None) -> (Tensor, Tensor, Tensor)",
+        "kerv_draft_action_topk(Tensor hidden, Tensor weight, int action_token_offset, int k, Tensor? bias=None) -> (Tensor, Tensor)",
+        "kerv_kv_accept_commit(Tensor(a!) storage, Tensor tree_indices, int previous_length, Tensor? scratch=None) -> Tensor(a!)",
+        "kerv_vision_add_layer_norm(Tensor hidden, Tensor residual, Tensor weight, Tensor? bias, float eps) -> Tensor",
+        "kerv_vision_bias_gelu(Tensor hidden, Tensor bias) -> Tensor",
+        "kerv_o_proj_residual_rms_norm(Tensor hidden, Tensor weight_proj, Tensor residual, Tensor norm_weight, float eps, Tensor? bias=None) -> Tensor",
+        "kerv_down_proj_residual_rms_norm(Tensor hidden, Tensor weight_proj, Tensor residual, Tensor norm_weight, float eps, Tensor? bias=None) -> Tensor",
+        "kerv_logical_kv_commit(Tensor(a!) logical_map, Tensor tree_indices, int previous_length) -> Tensor(a!)",
+    )
+    for definition in definitions:
+        _DEF_LIBRARY.define(definition)
+    _IMPL_LIBRARY = torch.library.Library("flagos_embodied", "IMPL", "CompositeExplicitAutograd")
+    implementations = {
+        "kerv_tree_embed_pack": _tree_embed_pack_impl,
+        "kerv_rope_kv_store": _rope_kv_store_impl,
+        "kerv_action_verify_accept": _action_verify_accept_impl,
+        "kerv_draft_action_topk": _draft_action_topk_impl,
+        "kerv_kv_accept_commit": _kv_accept_commit_impl,
+        "kerv_vision_add_layer_norm": _vision_add_layer_norm_impl,
+        "kerv_vision_bias_gelu": _vision_bias_gelu_impl,
+        "kerv_o_proj_residual_rms_norm": _o_proj_residual_rms_norm_impl,
+        "kerv_down_proj_residual_rms_norm": _down_proj_residual_rms_norm_impl,
+        "kerv_logical_kv_commit": _logical_kv_commit_impl,
+    }
+    for name, implementation in implementations.items():
+        _IMPL_LIBRARY.impl(name, implementation)
+
+
+def kerv_tree_embed_pack(draft_tokens, kept_indices, embedding_weight, target_nodes):
+    return torch.ops.flagos_embodied.kerv_tree_embed_pack(
+        draft_tokens, kept_indices, embedding_weight, int(target_nodes)
+    )
+
+
+def kerv_rope_kv_store(
+    query, key, value, cos, sin, position_ids, key_cache, value_cache, write_start
+):
+    return torch.ops.flagos_embodied.kerv_rope_kv_store(
+        query, key, value, cos, sin, position_ids, key_cache, value_cache, int(write_start)
+    )
+
+
+def kerv_action_verify_accept(hidden, weight, candidates, threshold, token_offset, bias=None):
+    return torch.ops.flagos_embodied.kerv_action_verify_accept(
+        hidden, weight, candidates, float(threshold), int(token_offset), bias
+    )
+
+
+def kerv_draft_action_topk(hidden, weight, action_token_offset, k=8, bias=None):
+    return torch.ops.flagos_embodied.kerv_draft_action_topk(
+        hidden, weight, int(action_token_offset), int(k), bias
+    )
+
+
+def kerv_kv_accept_commit(storage, tree_indices, previous_length, scratch=None):
+    return torch.ops.flagos_embodied.kerv_kv_accept_commit(
+        storage, tree_indices, int(previous_length), scratch
+    )
+
+
+def kerv_vision_add_layer_norm(hidden, residual, weight, bias, eps):
+    return torch.ops.flagos_embodied.kerv_vision_add_layer_norm(
+        hidden, residual, weight, bias, float(eps)
+    )
+
+
+def kerv_vision_bias_gelu(hidden, bias):
+    return torch.ops.flagos_embodied.kerv_vision_bias_gelu(hidden, bias)
+
+
+def kerv_o_proj_residual_rms_norm(hidden, weight_proj, residual, norm_weight, eps, bias=None):
+    return torch.ops.flagos_embodied.kerv_o_proj_residual_rms_norm(
+        hidden, weight_proj, residual, norm_weight, float(eps), bias
+    )
+
+
+def kerv_down_proj_residual_rms_norm(hidden, weight_proj, residual, norm_weight, eps, bias=None):
+    return torch.ops.flagos_embodied.kerv_down_proj_residual_rms_norm(
+        hidden, weight_proj, residual, norm_weight, float(eps), bias
+    )
+
+
+def kerv_logical_kv_commit(logical_map, tree_indices, previous_length):
+    return torch.ops.flagos_embodied.kerv_logical_kv_commit(
+        logical_map, tree_indices, int(previous_length)
+    )

--- a/flagscale/models/kerv/ops/KERVRuntimeOptimization/embodied_ops/runtime.py
+++ b/flagscale/models/kerv/ops/KERVRuntimeOptimization/embodied_ops/runtime.py
@@ -1,0 +1,156 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration and hit accounting for KERV FlagOS operators."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+from .kerv_ops import (
+    configure_backend,
+    configure_enabled_operators,
+    configure_recording,
+    register_kerv_ops,
+)
+from .static_tree_attention import (
+    configure_backend as configure_attention_backend,
+    configure_enabled as configure_attention_enabled,
+    register_static_tree_attention,
+)
+
+_PHASE2_MAINLINE = (
+    "kerv_tree_embed_pack",
+    "kerv_rope_kv_store",
+    "kerv_action_verify_accept",
+    "kerv_draft_action_topk",
+    "kerv_kv_accept_commit",
+    "kerv_vision_add_layer_norm",
+    "kerv_vision_bias_gelu",
+)
+
+_PHASE2_EXPERIMENTAL = (
+    "kerv_o_proj_residual_rms_norm",
+    "kerv_down_proj_residual_rms_norm",
+    "kerv_logical_kv_commit",
+)
+
+
+_DEFAULT_OPERATORS = (
+    "kerv_silu_mul",
+    "kerv_add_rms_norm",
+    "kerv_verify_accept_control",
+    "kerv_static_tree_pack",
+    "kerv_static_tree_attention",
+    "kerv_action_projection_select",
+    "kerv_kv_commit",
+    *_PHASE2_MAINLINE,
+)
+
+
+def _normalise_include(include: Iterable[str] | str | None) -> list[str]:
+    if include is None:
+        return list(_DEFAULT_OPERATORS)
+    if isinstance(include, str):
+        values = [item.strip() for item in include.split(",") if item.strip()]
+    else:
+        values = [str(item).strip() for item in include if str(item).strip()]
+    return list(dict.fromkeys(values))
+
+
+def kerv_ops_manifest(
+    *,
+    enabled: bool,
+    include: Iterable[str] | str | None = None,
+    backend: str = "auto",
+    record: bool = False,
+    record_once: bool = True,
+    log_path: str | None = None,
+    strict: bool = True,
+) -> dict[str, Any]:
+    operators = _normalise_include(include)
+    known = set(_DEFAULT_OPERATORS) | {"kerv_value_cache_store"} | set(_PHASE2_EXPERIMENTAL)
+    unknown = sorted(set(operators) - known)
+    if strict and unknown:
+        raise ValueError(f"unknown KERV embodied operators: {unknown}")
+    return {
+        "schema_version": 1,
+        "enabled": bool(enabled),
+        "backend": str(backend),
+        "requested_operators": operators,
+        "record": bool(record),
+        "record_once": bool(record_once),
+        "log_path": log_path,
+        "strict": bool(strict),
+        "native_fallback": True,
+        "operator_namespace": "flagos_embodied",
+        "mainline_operators": list(_PHASE2_MAINLINE),
+        "experimental_operators": list(_PHASE2_EXPERIMENTAL),
+        "performance_gate": {"min_local_speedup": 1.05, "e2e_target": 1.08},
+    }
+
+
+def configure_kerv_ops(
+    *,
+    enabled: bool = False,
+    include: Iterable[str] | str | None = None,
+    backend: str = "auto",
+    record: bool = False,
+    record_once: bool = True,
+    log_path: str | None = None,
+    manifest_path: str | None = None,
+    strict: bool = True,
+) -> dict[str, Any]:
+    """Install the public namespace and write an auditable configuration."""
+
+    manifest = kerv_ops_manifest(
+        enabled=enabled,
+        include=include,
+        backend=backend,
+        record=record,
+        record_once=record_once,
+        log_path=log_path,
+        strict=strict,
+    )
+    configure_recording(log_path, bool(enabled and record), bool(record_once))
+    configure_backend(backend)
+    configure_attention_backend(backend)
+    requested = set(manifest["requested_operators"]) if enabled else set()
+    configure_enabled_operators(requested)
+    configure_attention_enabled("kerv_static_tree_attention" in requested)
+    if enabled:
+        register_kerv_ops()
+        # register_kerv_ops extends the namespace with phase2_ops.  Importing
+        # explicitly here also covers applications that import runtime before
+        # the kerv_ops module has been eagerly loaded.
+        from .phase2_ops import register_phase2_ops
+
+        register_phase2_ops()
+        register_static_tree_attention()
+    if manifest_path:
+        path = Path(manifest_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8")
+    if enabled:
+        print(
+            "[FlagOS/KERV] embodied operators enabled: "
+            + ", ".join(manifest["requested_operators"]),
+            flush=True,
+        )
+    return manifest

--- a/flagscale/models/kerv/ops/KERVRuntimeOptimization/embodied_ops/static_tree_attention.py
+++ b/flagscale/models/kerv/ops/KERVRuntimeOptimization/embodied_ops/static_tree_attention.py
@@ -1,0 +1,527 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Flash-style attention specialized for fixed KERV verification trees."""
+
+from __future__ import annotations
+
+import math
+from types import MethodType
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except Exception:  # pragma: no cover
+    triton = None
+    tl = None
+
+
+if triton is not None:
+
+    @triton.jit
+    def _static_tree_attention_kernel(
+        q_ptr,
+        k_ptr,
+        v_ptr,
+        ancestors_ptr,
+        valid_prefix_ptr,
+        output_ptr,
+        stride_qh: tl.constexpr,
+        stride_qm: tl.constexpr,
+        stride_qd: tl.constexpr,
+        stride_kh: tl.constexpr,
+        stride_kn: tl.constexpr,
+        stride_kd: tl.constexpr,
+        stride_vh: tl.constexpr,
+        stride_vn: tl.constexpr,
+        stride_vd: tl.constexpr,
+        stride_am: tl.constexpr,
+        stride_aa: tl.constexpr,
+        stride_oh: tl.constexpr,
+        stride_om: tl.constexpr,
+        stride_od: tl.constexpr,
+        query_tokens: tl.constexpr,
+        prefix_capacity: tl.constexpr,
+        use_dynamic_prefix: tl.constexpr,
+        head_dim: tl.constexpr,
+        max_ancestors: tl.constexpr,
+        ancestor_count,
+        scale_log2: tl.constexpr,
+        block_m: tl.constexpr,
+        block_n: tl.constexpr,
+    ):
+        query_block = tl.program_id(0)
+        head = tl.program_id(1)
+        rows = query_block * block_m + tl.arange(0, block_m)
+        dims = tl.arange(0, head_dim)
+        row_mask = rows < query_tokens
+        q_offsets = head * stride_qh + rows[:, None] * stride_qm + dims[None, :] * stride_qd
+        query = tl.load(q_ptr + q_offsets, mask=row_mask[:, None], other=0.0)
+
+        running_max = tl.full((block_m,), -float("inf"), tl.float32)
+        running_sum = tl.zeros((block_m,), tl.float32)
+        accumulator = tl.zeros((block_m, head_dim), tl.float32)
+
+        valid_prefix_tokens = prefix_capacity
+        if use_dynamic_prefix:
+            valid_prefix_tokens = tl.load(valid_prefix_ptr)
+        for start in range(0, prefix_capacity, block_n):
+            columns = start + tl.arange(0, block_n)
+            column_mask = columns < valid_prefix_tokens
+            k_offsets = head * stride_kh + columns[:, None] * stride_kn + dims[None, :] * stride_kd
+            v_offsets = head * stride_vh + columns[:, None] * stride_vn + dims[None, :] * stride_vd
+            keys = tl.load(k_ptr + k_offsets, mask=column_mask[:, None], other=0.0)
+            scores = tl.dot(query, tl.trans(keys)) * scale_log2
+            scores = tl.where(row_mask[:, None] & column_mask[None, :], scores, -float("inf"))
+            block_max = tl.max(scores, axis=1)
+            next_max = tl.maximum(running_max, block_max)
+            correction = tl.exp2(running_max - next_max)
+            probabilities = tl.exp2(scores - next_max[:, None])
+            values = tl.load(v_ptr + v_offsets, mask=column_mask[:, None], other=0.0)
+            accumulator = accumulator * correction[:, None] + tl.dot(
+                probabilities.to(values.dtype), values
+            )
+            running_sum = running_sum * correction + tl.sum(probabilities, axis=1)
+            running_max = next_max
+
+        slots = tl.arange(0, max_ancestors)
+        ancestor_offsets = rows[:, None] * stride_am + slots[None, :] * stride_aa
+        ancestor_ids = tl.load(ancestors_ptr + ancestor_offsets, mask=row_mask[:, None], other=-1)
+        ancestor_valid = (
+            row_mask[:, None]
+            & (slots[None, :] < ancestor_count)
+            & (ancestor_ids >= prefix_capacity)
+        )
+        tree_k_offsets = (
+            head * stride_kh
+            + ancestor_ids[:, :, None] * stride_kn
+            + dims[None, None, :] * stride_kd
+        )
+        tree_v_offsets = (
+            head * stride_vh
+            + ancestor_ids[:, :, None] * stride_vn
+            + dims[None, None, :] * stride_vd
+        )
+        ancestor_keys = tl.load(k_ptr + tree_k_offsets, mask=ancestor_valid[:, :, None], other=0.0)
+        ancestor_scores = tl.sum(query[:, None, :] * ancestor_keys, axis=2) * scale_log2
+        ancestor_scores = tl.where(ancestor_valid, ancestor_scores, -float("inf"))
+        ancestor_max = tl.max(ancestor_scores, axis=1)
+        next_max = tl.maximum(running_max, ancestor_max)
+        correction = tl.exp2(running_max - next_max)
+        probabilities = tl.exp2(ancestor_scores - next_max[:, None])
+        ancestor_values = tl.load(
+            v_ptr + tree_v_offsets, mask=ancestor_valid[:, :, None], other=0.0
+        )
+        accumulator = accumulator * correction[:, None] + tl.sum(
+            probabilities[:, :, None] * ancestor_values, axis=1
+        )
+        running_sum = running_sum * correction + tl.sum(probabilities, axis=1)
+
+        output = accumulator / running_sum[:, None]
+        output_offsets = head * stride_oh + rows[:, None] * stride_om + dims[None, :] * stride_od
+        tl.store(output_ptr + output_offsets, output, mask=row_mask[:, None])
+
+
+def is_supported(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    ancestor_indices: torch.Tensor,
+    prefix_tokens: int,
+    valid_prefix_tokens: torch.Tensor | None = None,
+) -> bool:
+    dynamic_prefix_ok = bool(
+        valid_prefix_tokens is None
+        or (
+            valid_prefix_tokens.is_cuda
+            and valid_prefix_tokens.numel() == 1
+            and valid_prefix_tokens.dtype in (torch.int32, torch.int64)
+        )
+    )
+    return bool(
+        triton is not None
+        and query.is_cuda
+        and key.is_cuda
+        and value.is_cuda
+        and ancestor_indices.is_cuda
+        and query.ndim == key.ndim == value.ndim == 4
+        and query.shape[0] == key.shape[0] == value.shape[0] == 1
+        and query.shape[1] == key.shape[1] == value.shape[1]
+        and key.shape == value.shape
+        and query.shape[-1] == key.shape[-1] == 128
+        and query.dtype in (torch.float16, torch.bfloat16)
+        and query.dtype == key.dtype == value.dtype
+        and query.stride(-1) == key.stride(-1) == value.stride(-1) == 1
+        and ancestor_indices.ndim == 2
+        and ancestor_indices.shape[0] == query.shape[2]
+        and ancestor_indices.shape[1] in (4, 5, 8)
+        and ancestor_indices.dtype in (torch.int32, torch.int64)
+        and ancestor_indices.is_contiguous()
+        and 0 < int(prefix_tokens) <= key.shape[2]
+        and dynamic_prefix_ok
+    )
+
+
+def static_tree_attention_reference(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    ancestor_indices: torch.Tensor,
+    prefix_tokens: int,
+    scale: float | None = None,
+    valid_prefix_tokens: torch.Tensor | None = None,
+) -> torch.Tensor:
+    query_tokens = query.shape[2]
+    key_tokens = key.shape[2]
+    visible = torch.zeros((query_tokens, key_tokens), device=query.device, dtype=torch.bool)
+    valid_prefix = (
+        int(prefix_tokens)
+        if valid_prefix_tokens is None
+        else int(valid_prefix_tokens.reshape(-1)[0].item())
+    )
+    visible[:, :valid_prefix] = True
+    rows = torch.arange(query_tokens, device=query.device)[:, None]
+    valid = ancestor_indices >= int(prefix_tokens)
+    row_ids = rows.expand_as(ancestor_indices)[valid]
+    col_ids = ancestor_indices[valid].long()
+    visible[row_ids, col_ids] = True
+    scores = torch.matmul(query.float(), key.float().transpose(-1, -2))
+    scores *= scale if scale is not None else query.shape[-1] ** -0.5
+    scores.masked_fill_(~visible[None, None, :, :], -torch.inf)
+    return torch.matmul(torch.softmax(scores, dim=-1), value.float()).to(query.dtype)
+
+
+def static_tree_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    ancestor_indices: torch.Tensor,
+    prefix_tokens: int,
+    scale: float | None = None,
+    valid_prefix_tokens: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run the fast fixed-tree path, or the exact dense reference when needed."""
+
+    if (
+        not _ENABLED
+        # This kernel has a stable local speedup on its fixed KERV layout, so
+        # auto mode may use it.  Other embodied kernels remain conservative.
+        or _BACKEND not in {"auto", "triton"}
+        or not is_supported(
+            query,
+            key,
+            value,
+            ancestor_indices,
+            prefix_tokens,
+            valid_prefix_tokens,
+        )
+    ):
+        return static_tree_attention_reference(
+            query,
+            key,
+            value,
+            ancestor_indices,
+            prefix_tokens,
+            scale,
+            valid_prefix_tokens,
+        )
+    output = torch.empty_like(query)
+    head_dim = int(query.shape[-1])
+    # KERV's verification trees are wide (224--320 nodes) while each query
+    # only follows at most eight ancestors.  A 16-row tile reduces register
+    # pressure on A100; the previous 32-row tile measured about 9% slower.
+    block_m, block_n = 16, 64
+    attention_scale = (scale if scale is not None else head_dim**-0.5) * math.log2(math.e)
+    grid = (triton.cdiv(query.shape[2], block_m), query.shape[1])
+    ancestor_count = int(ancestor_indices.shape[1])
+    ancestor_block = triton.next_power_of_2(ancestor_count)
+    if ancestor_block != ancestor_count:
+        padded = torch.full(
+            (ancestor_indices.shape[0], ancestor_block),
+            -1,
+            device=ancestor_indices.device,
+            dtype=ancestor_indices.dtype,
+        )
+        padded[:, :ancestor_count].copy_(ancestor_indices)
+        ancestor_indices = padded
+    _static_tree_attention_kernel[grid](
+        query,
+        key,
+        value,
+        ancestor_indices,
+        valid_prefix_tokens if valid_prefix_tokens is not None else ancestor_indices,
+        output,
+        query.stride(1),
+        query.stride(2),
+        query.stride(3),
+        key.stride(1),
+        key.stride(2),
+        key.stride(3),
+        value.stride(1),
+        value.stride(2),
+        value.stride(3),
+        ancestor_indices.stride(0),
+        ancestor_indices.stride(1),
+        output.stride(1),
+        output.stride(2),
+        output.stride(3),
+        query.shape[2],
+        int(prefix_tokens),
+        valid_prefix_tokens is not None,
+        head_dim,
+        ancestor_block,
+        ancestor_count,
+        attention_scale,
+        block_m,
+        block_n,
+        num_warps=4,
+        num_stages=1,
+    )
+    return output
+
+
+_LIBRARY: torch.library.Library | None = None
+_IMPL_LIBRARY: torch.library.Library | None = None
+_BACKEND = "auto"
+_ENABLED = True
+
+
+def configure_backend(backend: str) -> None:
+    global _BACKEND
+    backend = str(backend).lower()
+    if backend not in {"auto", "triton", "native"}:
+        raise ValueError(f"unsupported KERV embodied backend: {backend}")
+    _BACKEND = backend
+
+
+def configure_enabled(enabled: bool) -> None:
+    global _ENABLED
+    _ENABLED = bool(enabled)
+
+
+def install_static_tree_attention(model) -> list[str]:
+    """Install an opt-in verifier hook on compatible Llama attention layers.
+
+    The hook is deliberately disabled by the default ``auto`` KERV profile;
+    callers select ``backend=triton`` after an exact closed-loop comparison.
+    If a model uses an unsupported cache or mask layout, the original HF
+    attention implementation is called unchanged.
+    """
+
+    if getattr(model, "_flagos_static_tree_attention_installed", False):
+        return list(getattr(model, "_flagos_static_tree_attention_targets", ()))
+    language_model = getattr(getattr(model, "base_model", None), "language_model", None)
+    if language_model is None:
+        return []
+    try:
+        from transformers.models.llama.modeling_llama import (
+            repeat_kv as hf_repeat_kv,
+        )
+    except Exception:
+        return []
+
+    targets: list[str] = []
+    for name, module in language_model.named_modules():
+        if (
+            not all(
+                hasattr(module, attr)
+                for attr in ("q_proj", "k_proj", "v_proj", "o_proj", "rotary_emb")
+            )
+            or not hasattr(module, "num_heads")
+            or getattr(module, "_flagos_static_tree_attention_wrapped", False)
+        ):
+            continue
+        original = module.forward
+
+        def static_forward(
+            self,
+            hidden_states,
+            attention_mask=None,
+            position_ids=None,
+            past_key_value=None,
+            output_attentions=False,
+            use_cache=False,
+            cache_position=None,
+            _original=original,
+            **kwargs,
+        ):
+            if (
+                _BACKEND not in {"auto", "triton"}
+                or not _ENABLED
+                or not bool(
+                    getattr(
+                        language_model,
+                        "_flagos_static_tree_attention_runtime_enabled",
+                        False,
+                    )
+                )
+                or self.training
+                or output_attentions
+                or not isinstance(attention_mask, torch.Tensor)
+                or not attention_mask.dtype.is_floating_point
+                or attention_mask.ndim != 4
+                or attention_mask.shape[0] != 1
+                or attention_mask.shape[1] != 1
+                or not hidden_states.is_cuda
+                or not attention_mask.is_cuda
+                or hidden_states.ndim != 3
+                or hidden_states.shape[0] != 1
+                or hidden_states.shape[1] <= 1
+            ):
+                return _original(
+                    hidden_states,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    past_key_value=past_key_value,
+                    output_attentions=output_attentions,
+                    use_cache=use_cache,
+                    cache_position=cache_position,
+                    **kwargs,
+                )
+            bsz, query_tokens, _ = hidden_states.shape
+            # Inspect the fixed mask before touching the cache.  This keeps
+            # every unsupported case on the original HF path without a
+            # partially updated DynamicCache.
+            if self.config.pretraining_tp != 1:
+                return _original(
+                    hidden_states,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    past_key_value=past_key_value,
+                    output_attentions=output_attentions,
+                    use_cache=use_cache,
+                    cache_position=cache_position,
+                    **kwargs,
+                )
+            past_key_value = getattr(self, "past_key_value", past_key_value)
+            persistent = bool(
+                getattr(past_key_value, "_flagos_persistent_tree_cache", False)
+                and getattr(past_key_value, "fixed_workspace_layout", False)
+            )
+            ancestor_indices = getattr(past_key_value, "current_ancestor_indices", None)
+            tree_start = int(getattr(past_key_value, "prefix_capacity", 0))
+            key_tokens = int(attention_mask.shape[-1])
+            if (
+                not persistent
+                or not isinstance(ancestor_indices, torch.Tensor)
+                or ancestor_indices.shape != (query_tokens, 8)
+                or tree_start <= 0
+                or key_tokens != tree_start + query_tokens
+            ):
+                return _original(
+                    hidden_states,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    past_key_value=past_key_value,
+                    output_attentions=output_attentions,
+                    use_cache=use_cache,
+                    cache_position=cache_position,
+                    **kwargs,
+                )
+            try:
+                query_states = (
+                    self.q_proj(hidden_states)
+                    .view(bsz, query_tokens, self.num_heads, self.head_dim)
+                    .transpose(1, 2)
+                )
+                key_states = (
+                    self.k_proj(hidden_states)
+                    .view(bsz, query_tokens, self.num_key_value_heads, self.head_dim)
+                    .transpose(1, 2)
+                )
+                value_states = (
+                    self.v_proj(hidden_states)
+                    .view(bsz, query_tokens, self.num_key_value_heads, self.head_dim)
+                    .transpose(1, 2)
+                )
+                cos, sin = self.rotary_emb(value_states, position_ids)
+                key_destination = past_key_value.rotary_key_destination(
+                    int(self.layer_idx), query_tokens
+                )
+                value_destination = past_key_value.rotary_value_destination(
+                    int(self.layer_idx), query_tokens
+                )
+                query_states = torch.ops.flagos_embodied.kerv_rope_kv_store(
+                    query_states,
+                    key_states,
+                    value_states,
+                    cos,
+                    sin,
+                    past_key_value.empty_position_ids,
+                    past_key_value.storage[int(self.layer_idx), 0],
+                    past_key_value.storage[int(self.layer_idx), 1],
+                    tree_start,
+                )
+                past_key_value.mark_rotary_value_written(int(self.layer_idx), query_tokens)
+                cache_kwargs = {
+                    "sin": sin,
+                    "cos": cos,
+                    "cache_position": cache_position,
+                }
+                key_states, value_states = past_key_value.update(
+                    key_destination,
+                    value_destination,
+                    self.layer_idx,
+                    cache_kwargs,
+                )
+                key_states = hf_repeat_kv(key_states, self.num_key_value_groups)
+                value_states = hf_repeat_kv(value_states, self.num_key_value_groups)
+                if int(key_states.shape[-2]) != key_tokens:
+                    raise RuntimeError("static tree attention cache length changed")
+                output = torch.ops.flagos_embodied.kerv_static_tree_attention(
+                    query_states,
+                    key_states,
+                    value_states,
+                    ancestor_indices,
+                    tree_start,
+                    self.head_dim**-0.5,
+                    past_key_value.prefix_length_tensor,
+                )
+                output = output.transpose(1, 2).reshape(bsz, query_tokens, self.hidden_size)
+                output = self.o_proj(output)
+                language_model._flagos_static_tree_attention_hits = (
+                    int(getattr(language_model, "_flagos_static_tree_attention_hits", 0)) + 1
+                )
+                return output, None, past_key_value
+            except Exception as exc:
+                raise RuntimeError("static tree attention execution failed") from exc
+
+        module.forward = MethodType(static_forward, module)
+        module._flagos_static_tree_attention_wrapped = True
+        targets.append(name)
+    model._flagos_static_tree_attention_installed = True
+    model._flagos_static_tree_attention_targets = targets
+    return targets
+
+
+def register_static_tree_attention() -> None:
+    global _LIBRARY, _IMPL_LIBRARY
+    if _LIBRARY is not None:
+        return
+    # kerv_ops owns the namespace definition; a fragment lets this module add
+    # the attention schema without creating a second TORCH_LIBRARY block.
+    library = torch.library.Library("flagos_embodied", "FRAGMENT")
+    library.define(
+        "kerv_static_tree_attention(Tensor query, Tensor key, Tensor value, "
+        "Tensor ancestor_indices, int prefix_tokens, float? scale=None, "
+        "Tensor? valid_prefix_tokens=None) -> Tensor"
+    )
+    _IMPL_LIBRARY = torch.library.Library("flagos_embodied", "IMPL", "CompositeExplicitAutograd")
+    _IMPL_LIBRARY.impl("kerv_static_tree_attention", static_tree_attention)
+    _LIBRARY = library
+
+
+register_static_tree_attention()

--- a/flagscale/models/kerv/ops/KERVRuntimeOptimization/fused_logsoftmax_topk.py
+++ b/flagscale/models/kerv/ops/KERVRuntimeOptimization/fused_logsoftmax_topk.py
@@ -1,0 +1,191 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""KERV-specialized fused LogSoftmax+TopK for wide, short-batch logits."""
+
+from __future__ import annotations
+
+import torch
+
+_TRITON_AVAILABLE = True
+try:
+    import triton
+    import triton.language as tl
+except Exception:  # pragma: no cover - exercised on non-Triton platforms.
+    _TRITON_AVAILABLE = False
+
+    class _TritonStub:
+        @staticmethod
+        def jit(function=None, **_kwargs):
+            if function is not None:
+                return function
+            return lambda candidate: candidate
+
+    class _LanguageStub:
+        constexpr = object()
+
+    triton = _TritonStub()
+    tl = _LanguageStub()
+
+
+@triton.jit
+def _chunk_logsumexp_topk(
+    logits,
+    partial_max,
+    partial_sum,
+    candidate_values,
+    candidate_indices,
+    rows: tl.constexpr,
+    cols,
+    chunks: tl.constexpr,
+    stride_row,
+    CHUNK: tl.constexpr,
+    TOPK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    chunk = tl.program_id(1)
+    offsets = chunk * CHUNK + tl.arange(0, CHUNK)
+    valid = offsets < cols
+    values = tl.load(
+        logits + row * stride_row + offsets,
+        mask=valid,
+        other=-float("inf"),
+    ).to(tl.float32)
+
+    chunk_max = tl.max(values, axis=0)
+    chunk_sum = tl.sum(tl.exp(values - chunk_max), axis=0)
+    partial_offset = row * chunks + chunk
+    tl.store(partial_max + partial_offset, chunk_max)
+    tl.store(partial_sum + partial_offset, chunk_sum)
+
+    candidate_offset = partial_offset * TOPK
+    mutable = values
+    lane = tl.arange(0, CHUNK)
+    for rank in tl.static_range(TOPK):
+        top_value, top_lane = tl.max(mutable, axis=0, return_indices=True)
+        tl.store(candidate_values + candidate_offset + rank, top_value)
+        tl.store(candidate_indices + candidate_offset + rank, chunk * CHUNK + top_lane)
+        mutable = tl.where(lane == top_lane, -float("inf"), mutable)
+
+
+@triton.jit
+def _merge_logsumexp_topk(
+    partial_max,
+    partial_sum,
+    candidate_values,
+    candidate_indices,
+    output_values,
+    output_indices,
+    chunks: tl.constexpr,
+    CANDIDATES: tl.constexpr,
+    TOPK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    chunk_lanes = tl.arange(0, triton.next_power_of_2(chunks))
+    chunk_mask = chunk_lanes < chunks
+    max_values = tl.load(
+        partial_max + row * chunks + chunk_lanes,
+        mask=chunk_mask,
+        other=-float("inf"),
+    )
+    sums = tl.load(
+        partial_sum + row * chunks + chunk_lanes,
+        mask=chunk_mask,
+        other=0.0,
+    )
+    global_max = tl.max(max_values, axis=0)
+    global_sum = tl.sum(sums * tl.exp(max_values - global_max), axis=0)
+    log_normalizer = global_max + tl.log(global_sum)
+
+    lanes = tl.arange(0, CANDIDATES)
+    valid = lanes < chunks * TOPK
+    base = row * chunks * TOPK
+    values = tl.load(candidate_values + base + lanes, mask=valid, other=-float("inf"))
+    indices = tl.load(candidate_indices + base + lanes, mask=valid, other=0)
+    mutable = values
+    output_base = row * TOPK
+    for rank in tl.static_range(TOPK):
+        top_value, top_lane = tl.max(mutable, axis=0, return_indices=True)
+        top_index = tl.sum(tl.where(lanes == top_lane, indices, 0), axis=0)
+        tl.store(output_values + output_base + rank, top_value - log_normalizer)
+        tl.store(output_indices + output_base + rank, top_index)
+        mutable = tl.where(lanes == top_lane, -float("inf"), mutable)
+
+
+def fused_logsoftmax_topk(
+    logits: torch.Tensor,
+    k: int = 8,
+    chunk_size: int = 1024,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return the same interface as ``torch.topk(log_softmax(logits), k)``.
+
+    This path is intentionally narrow: inference-only, contiguous FP32 CUDA
+    logits, K=8, and vocabulary width between 16K and 64K. BF16/FP16 logits
+    use PyTorch so quantized ties preserve KERV's original candidate order.
+    """
+    if not _TRITON_AVAILABLE or logits.dtype != torch.float32:
+        probabilities = torch.nn.functional.log_softmax(logits, dim=-1)
+        result = torch.topk(probabilities, k, dim=-1)
+        return result.values, result.indices
+    if not (
+        logits.is_cuda
+        and logits.is_contiguous()
+        and logits.ndim == 2
+        and logits.dtype == torch.float32
+        and int(k) == 8
+        and int(chunk_size) == 1024
+        and 16384 <= int(logits.shape[1]) <= 65536
+    ):
+        raise ValueError("unsupported fused LogSoftmax+TopK input")
+
+    rows, cols = map(int, logits.shape)
+    chunks = triton.cdiv(cols, chunk_size)
+    partial_max = torch.empty((rows, chunks), device=logits.device, dtype=torch.float32)
+    partial_sum = torch.empty_like(partial_max)
+    candidate_values = torch.empty((rows, chunks, k), device=logits.device, dtype=torch.float32)
+    candidate_indices = torch.empty((rows, chunks, k), device=logits.device, dtype=torch.int32)
+    output_values = torch.empty((rows, k), device=logits.device, dtype=logits.dtype)
+    output_indices = torch.empty((rows, k), device=logits.device, dtype=torch.int64)
+
+    _chunk_logsumexp_topk[(rows, chunks)](
+        logits,
+        partial_max,
+        partial_sum,
+        candidate_values,
+        candidate_indices,
+        rows,
+        cols,
+        chunks,
+        logits.stride(0),
+        CHUNK=chunk_size,
+        TOPK=k,
+        num_warps=8,
+    )
+    candidates = triton.next_power_of_2(chunks * k)
+    _merge_logsumexp_topk[(rows,)](
+        partial_max,
+        partial_sum,
+        candidate_values,
+        candidate_indices,
+        output_values,
+        output_indices,
+        chunks=chunks,
+        CANDIDATES=candidates,
+        TOPK=k,
+        num_warps=4,
+    )
+    return output_values, output_indices
+
+
+__all__ = ["fused_logsoftmax_topk"]

--- a/flagscale/models/kerv/ops/KERVRuntimeOptimization/rotary_cache.py
+++ b/flagscale/models/kerv/ops/KERVRuntimeOptimization/rotary_cache.py
@@ -1,0 +1,197 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-forward RoPE cache for transformer stacks with identical rotary modules."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import MethodType
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+
+class _ForwardRotaryCache:
+    def __init__(self, log_path: str | None, record: bool, record_once: bool):
+        self.log_path = Path(log_path) if record and log_path else None
+        self.record_once = bool(record_once)
+        self.recorded = set()
+        self.value = None
+        self.position_ids = None
+        self.dtype = None
+        self.misses = 0
+        self.hits = 0
+        self.layer_count = 0
+        self.validated = set()
+        self.rejected = set()
+        if self.log_path is not None:
+            self.log_path.parent.mkdir(parents=True, exist_ok=True)
+            self.log_path.touch(exist_ok=True)
+
+    def begin(self) -> None:
+        self.value = None
+        self.position_ids = None
+        self.dtype = None
+
+    def get(self, original, value: torch.Tensor, position_ids: torch.Tensor):
+        if self.value is None or self.position_ids is not position_ids or self.dtype != value.dtype:
+            self.value = original(value, position_ids)
+            self.position_ids = position_ids
+            self.dtype = value.dtype
+            self.misses += 1
+            return self.value
+
+        owner = getattr(original, "__self__", None)
+        validation_key = (
+            id(owner),
+            tuple(position_ids.shape),
+            str(value.dtype),
+            str(value.device),
+        )
+        if validation_key in self.rejected:
+            return original(value, position_ids)
+        if validation_key not in self.validated:
+            reference = original(value, position_ids)
+            exact = bool(
+                len(reference) == len(self.value)
+                and all(
+                    torch.equal(candidate, cached)
+                    for candidate, cached in zip(reference, self.value)
+                )
+            )
+            if not exact:
+                self.rejected.add(validation_key)
+                return reference
+            self.validated.add(validation_key)
+
+        self.hits += 1
+        if self.log_path is not None:
+            key = (tuple(position_ids.shape), str(value.dtype), int(position_ids.shape[-1]))
+            if not self.record_once or key not in self.recorded:
+                self.recorded.add(key)
+                record = {
+                    "operator": "rotary_embedding_cache",
+                    "implementation": "flagos_per_forward_rope_cache",
+                    "position_shape": list(position_ids.shape),
+                    "dtype": str(value.dtype).removeprefix("torch."),
+                    "reused_layers": max(0, self.layer_count - 1),
+                    "bitwise_validated": True,
+                }
+                with self.log_path.open("a", encoding="utf-8") as handle:
+                    handle.write(json.dumps(record) + "\n")
+        return self.value
+
+
+def _install_on_language_model(
+    language_model: nn.Module,
+    cache: _ForwardRotaryCache,
+) -> int:
+    if getattr(language_model, "_flagos_rope_cache_installed", False):
+        raise RuntimeError("FlagOS RoPE cache is already installed")
+    layers = list(getattr(getattr(language_model, "model", None), "layers", ()))
+    rotary_modules = [
+        getattr(getattr(layer, "self_attn", None), "rotary_emb", None) for layer in layers
+    ]
+    if len(rotary_modules) < 2 or any(module is None for module in rotary_modules):
+        return 0
+
+    reference = rotary_modules[0].inv_freq
+    reference_signature = (
+        tuple(reference.shape),
+        reference.dtype,
+        reference.device,
+        getattr(rotary_modules[0], "dim", None),
+        getattr(rotary_modules[0], "base", None),
+        getattr(rotary_modules[0], "max_position_embeddings", None),
+        getattr(rotary_modules[0], "scaling_factor", None),
+    )
+    for module in rotary_modules[1:]:
+        inv_freq = getattr(module, "inv_freq", None)
+        signature = (
+            tuple(inv_freq.shape) if isinstance(inv_freq, torch.Tensor) else None,
+            getattr(inv_freq, "dtype", None),
+            getattr(inv_freq, "device", None),
+            getattr(module, "dim", None),
+            getattr(module, "base", None),
+            getattr(module, "max_position_embeddings", None),
+            getattr(module, "scaling_factor", None),
+        )
+        if not isinstance(inv_freq, torch.Tensor) or signature != reference_signature:
+            return 0
+
+    original_model_forward = language_model.model_forward
+
+    def cached_model_forward(self, *args, **kwargs):
+        cache.begin()
+        return original_model_forward(*args, **kwargs)
+
+    language_model.model_forward = MethodType(cached_model_forward, language_model)
+
+    for rotary in rotary_modules:
+        original_rotary_forward = rotary.forward
+
+        def cached_rotary_forward(self, value, position_ids, _original=original_rotary_forward):
+            return cache.get(_original, value, position_ids)
+
+        rotary.forward = MethodType(cached_rotary_forward, rotary)
+
+    language_model._flagos_rope_cache_installed = True
+    language_model._flagos_rope_cache = cache
+    cache.layer_count = max(cache.layer_count, len(rotary_modules))
+    return len(rotary_modules)
+
+
+def enable_rotary_cache(
+    model: nn.Module,
+    enabled: bool,
+    record: bool,
+    record_once: bool,
+    log_path: str | None,
+    manifest_path: str | None,
+) -> dict[str, Any]:
+    """Reuse identical RoPE cos/sin tensors across decoder layers in one forward."""
+    if record and enabled and not log_path:
+        raise ValueError("RoPE cache recording requires a log path")
+    cache = _ForwardRotaryCache(log_path, record and enabled, record_once)
+    targets = []
+    if enabled:
+        for name, module in model.named_modules():
+            if type(module).__name__ == "LlamaSpecForCausalLM" and hasattr(module, "model_forward"):
+                layer_count = _install_on_language_model(module, cache)
+                if layer_count:
+                    targets.append({"module": name, "layer_count": layer_count})
+        if not targets:
+            raise RuntimeError("FlagOS RoPE cache found no compatible language model")
+
+    manifest: dict[str, Any] = {
+        "enabled": bool(enabled),
+        "implementation": "flagos_per_forward_rope_cache",
+        "model_class": type(model).__name__,
+        "target_count": len(targets),
+        "targets": targets,
+        "native_fallback": True,
+        "inference_only": True,
+    }
+    if manifest_path:
+        path = Path(manifest_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(
+        f"[FlagOS/RoPECache] {'enabled' if enabled else 'disabled'}; targets={targets}",
+        flush=True,
+    )
+    return manifest

--- a/flagscale/models/kerv/ops/KERVRuntimeOptimization/tree_attention_mask.py
+++ b/flagscale/models/kerv/ops/KERVRuntimeOptimization/tree_attention_mask.py
@@ -1,0 +1,230 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-kernel causal mask construction for KERV verification trees."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import MethodType
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+_TRITON_AVAILABLE = True
+try:
+    import triton
+    import triton.language as tl
+except Exception:  # pragma: no cover - exercised on non-Triton platforms.
+    _TRITON_AVAILABLE = False
+
+    class _TritonStub:
+        @staticmethod
+        def jit(function=None, **_kwargs):
+            if function is not None:
+                return function
+            return lambda candidate: candidate
+
+    class _LanguageStub:
+        constexpr = object()
+
+    triton = _TritonStub()
+    tl = _LanguageStub()
+
+
+@triton.jit(do_not_specialize=["past_length", "tree_length", "total_length"])
+def _tree_causal_mask_kernel(
+    tree_mask,
+    output,
+    tree_stride_row: tl.constexpr,
+    output_stride_row: tl.constexpr,
+    past_length,
+    tree_start,
+    tree_length,
+    total_length,
+    min_value: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    column = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    valid = (row < tree_length) & (column < total_length)
+    tree_column = column - tree_start
+    in_tree = column >= tree_start
+    tree_valid = valid & in_tree & (tree_column < tree_length)
+    allowed = (
+        tl.load(
+            tree_mask + row * tree_stride_row + tree_column,
+            mask=tree_valid,
+            other=1,
+        )
+        != 0
+    )
+    future = tree_column > row
+    prefix_gap = (column >= past_length) & (column < tree_start)
+    value = tl.where(prefix_gap | (in_tree & (~allowed | future)), min_value, 0.0)
+    tl.store(output + row * output_stride_row + column, value, mask=valid)
+
+
+def build_tree_causal_mask(
+    tree_mask: torch.Tensor,
+    past_length: int,
+    dtype: torch.dtype,
+    output: torch.Tensor | None = None,
+    tree_start: int | None = None,
+) -> torch.Tensor:
+    if not _TRITON_AVAILABLE:
+        raise ValueError("tree attention mask kernel requires Triton")
+    if tree_mask.device.type != "cuda" or not tree_mask.is_contiguous():
+        raise ValueError("tree attention mask kernel requires a contiguous CUDA tree mask")
+    tree_length = int(tree_mask.shape[-1])
+    if int(tree_mask.shape[-2]) != tree_length:
+        raise ValueError("tree attention mask must be square")
+    tree_start = int(past_length) if tree_start is None else int(tree_start)
+    if tree_start < int(past_length):
+        raise ValueError("tree_start cannot precede the valid prefix")
+    total_length = tree_start + tree_length
+    expected_shape = (1, 1, tree_length, total_length)
+    if output is None:
+        output = torch.empty(
+            expected_shape,
+            device=tree_mask.device,
+            dtype=dtype,
+        )
+    elif (
+        tuple(output.shape) != expected_shape
+        or output.device != tree_mask.device
+        or output.dtype != dtype
+        or not output.is_contiguous()
+    ):
+        raise ValueError("resident tree-mask output has an incompatible layout")
+    block = 256
+    _tree_causal_mask_kernel[(tree_length, triton.cdiv(total_length, block))](
+        tree_mask,
+        output,
+        tree_stride_row=tree_mask.stride(-2),
+        output_stride_row=output.stride(-2),
+        past_length=int(past_length),
+        tree_start=tree_start,
+        tree_length=tree_length,
+        total_length=total_length,
+        min_value=float(torch.finfo(dtype).min),
+        BLOCK=block,
+    )
+    return output
+
+
+def enable_tree_attention_mask(
+    model: nn.Module,
+    enabled: bool,
+    record: bool,
+    record_once: bool,
+    log_path: str | None,
+    manifest_path: str | None,
+) -> dict[str, Any]:
+    """Route KERV tree-only masks through one Triton construction kernel."""
+    record_path = Path(log_path) if enabled and record and log_path else None
+    if enabled and record and record_path is None:
+        raise ValueError("tree attention mask recording requires a log path")
+    if record_path is not None:
+        record_path.parent.mkdir(parents=True, exist_ok=True)
+        record_path.touch(exist_ok=True)
+    recorded = set()
+    targets = []
+
+    selected = bool(enabled and _TRITON_AVAILABLE)
+    if selected:
+        for name, module in model.named_modules():
+            if type(module).__name__ != "LlamaSpecForCausalLM" or not hasattr(
+                module, "_update_causal_mask"
+            ):
+                continue
+            original = module._update_causal_mask
+
+            def fast_update_causal_mask(
+                self,
+                attention_mask,
+                input_tensor,
+                cache_position,
+                past_seen_tokens,
+                _original=original,
+            ):
+                tree_mask = getattr(self, "tree_mask", None)
+                if (
+                    attention_mask is None
+                    and isinstance(tree_mask, torch.Tensor)
+                    and tree_mask.device.type == "cuda"
+                    and tree_mask.is_contiguous()
+                    and int(tree_mask.shape[-1]) == int(input_tensor.shape[1])
+                ):
+                    result = build_tree_causal_mask(
+                        tree_mask,
+                        int(past_seen_tokens),
+                        input_tensor.dtype,
+                    )
+                    self._flagos_tree_attention_mask_hits = (
+                        int(getattr(self, "_flagos_tree_attention_mask_hits", 0)) + 1
+                    )
+                    if record_path is not None:
+                        key = (
+                            int(tree_mask.shape[-1]),
+                            int(past_seen_tokens),
+                            str(input_tensor.dtype),
+                        )
+                        if not record_once or key not in recorded:
+                            recorded.add(key)
+                            event = {
+                                "operator": "tree_causal_attention_mask",
+                                "implementation": "flagos_triton_dynamic_tree_mask",
+                                "tree_length": key[0],
+                                "past_length": key[1],
+                                "dtype": str(input_tensor.dtype).removeprefix("torch."),
+                            }
+                            with record_path.open("a", encoding="utf-8") as handle:
+                                handle.write(json.dumps(event) + "\n")
+                    return result
+                return _original(
+                    attention_mask,
+                    input_tensor,
+                    cache_position,
+                    past_seen_tokens,
+                )
+
+            module._update_causal_mask = MethodType(fast_update_causal_mask, module)
+            module._flagos_tree_attention_mask_installed = True
+            targets.append(name)
+
+        if not targets:
+            raise RuntimeError("tree attention mask kernel found no compatible language model")
+
+    manifest: dict[str, Any] = {
+        "enabled": selected,
+        "requested": bool(enabled),
+        "implementation": "flagos_triton_dynamic_tree_mask",
+        "model_class": type(model).__name__,
+        "targets": targets,
+        "native_fallback": True,
+        "inference_only": True,
+        "unavailable_reason": None if _TRITON_AVAILABLE else "Triton is unavailable",
+    }
+    if manifest_path:
+        path = Path(manifest_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(
+        f"[FlagOS/TreeAttentionMask] {'enabled' if selected else 'disabled'}; targets={targets}",
+        flush=True,
+    )
+    return manifest

--- a/flagscale/models/kerv/ops/README.md
+++ b/flagscale/models/kerv/ops/README.md
@@ -1,0 +1,95 @@
+# KERV optimized runtime
+
+This directory is the KERV-specific runtime shipped with the FlagScale model
+integration. It is intentionally scoped to KERV's batch-one speculative
+decoding path and does not register global replacements for unrelated models.
+
+## Runtime integration
+
+KERV imports its runtime through the canonical top-level package
+`KERVRuntimeOptimization`. Before invoking an upstream KERV entrypoint,
+FlagScale prepends this directory to `PYTHONPATH`. This makes the source
+checkout use the implementation versioned with FlagScale and avoids loading a
+second operator package from the checkout.
+
+```text
+flagscale/models/kerv/ops/
+└── KERVRuntimeOptimization/
+    ├── embodied_ops/              # 18 torch.library operator interfaces
+    ├── adaptive_linear_fusion.py  # packed QKV/Gate-Up and fusion hooks
+    ├── adaptive_rms_norm.py       # inference RMSNorm hook
+    ├── adaptive_rotary_fusion.py  # Q/K RoPE and resident-cache hook
+    ├── fused_logsoftmax_topk.py   # draft LogSoftmax/Top-K path
+    ├── rotary_cache.py            # per-forward rotary cache
+    └── tree_attention_mask.py     # verification-tree mask path
+```
+
+The operator namespace remains `torch.ops.flagos_embodied.*` to preserve the
+public KERV contract.
+
+## Operator inventory
+
+The default KERV profile requests 14 interfaces. Three additional interfaces
+remain experimental, and one V-cache interface is retained for compatibility
+with earlier KERV configurations.
+
+| Operator | Function | Status |
+| --- | --- | --- |
+| `kerv_silu_mul` | `SiLU(gate) * up` post-GEMM fusion | KERV profile |
+| `kerv_add_rms_norm` | residual add and RMSNorm | KERV profile |
+| `kerv_verify_accept_control` | token matching, prefix length and best-path reduction | KERV profile |
+| `kerv_static_tree_pack` | static-tree token gather and padding | KERV profile |
+| `kerv_static_tree_attention` | prefix-and-ancestor attention for a fixed verification tree | KERV profile, A100 Triton route |
+| `kerv_action_projection_select` | action-vocabulary projection and argmax | KERV profile |
+| `kerv_kv_commit` | resident K/V cache commit | KERV profile |
+| `kerv_tree_embed_pack` | candidate gather, padding and embedding lookup | KERV profile |
+| `kerv_rope_kv_store` | Q/K RoPE plus resident K/V write | KERV profile, A100 Triton route |
+| `kerv_action_verify_accept` | action projection, verification and next-token selection | KERV profile |
+| `kerv_draft_action_topk` | action projection, LogSoftmax and deterministic Top-K | KERV profile |
+| `kerv_kv_accept_commit` | accepted-path gather and K/V commit | KERV profile |
+| `kerv_vision_add_layer_norm` | vision residual add and LayerNorm | KERV profile |
+| `kerv_vision_bias_gelu` | vision bias add and GELU | KERV profile |
+| `kerv_o_proj_residual_rms_norm` | attention output projection epilogue | Experimental |
+| `kerv_down_proj_residual_rms_norm` | MLP down-projection epilogue | Experimental |
+| `kerv_logical_kv_commit` | logical cache-address commit | Experimental |
+| `kerv_value_cache_store` | V-only cache write | Compatibility; covered by RoPE/KV store in the default profile |
+
+Every interface has an exact PyTorch implementation. Triton is optional at
+import time; unsupported devices and layouts use the platform-native
+implementation. Experimental interfaces are never selected implicitly.
+
+## A100 selection policy
+
+`backend=auto` selects a Triton implementation only after the real KERV shape
+passes a 1.05x local speed threshold. With 100 warmups, 200 timed iterations
+and five median windows on an NVIDIA A100-PCIE-40GB, the current automatic
+routes are:
+
+| Operator | PyTorch | Triton | Speedup | Correctness |
+| --- | ---: | ---: | ---: | --- |
+| `kerv_rope_kv_store` | 0.1556 ms | 0.0889 ms | 1.75x | BF16 pass |
+| `kerv_static_tree_attention` | 0.3602 ms | 0.0892 ms | 4.04x | BF16 pass |
+
+The other public interfaces remain available to KERV but use their exact
+PyTorch route in `auto` mode. A correct interface is not described as an
+accelerated kernel until it passes the backend-specific timing threshold.
+
+## Validation
+
+Run all KERV integration and operator tests:
+
+```bash
+pytest tests/unit_tests/models/kerv -q
+```
+
+Run the A100 microbenchmark:
+
+```bash
+python examples/kerv/benchmark_ops.py \
+  --device cuda --backend auto \
+  --warmup 100 --iterations 200 --repeats 5
+```
+
+The tests cover all 18 schemas, CPU implementations, Triton-free imports,
+BF16 CUDA correctness, fixed-prefix tree masking, namespace registration, and
+the actual FlagScale-to-KERV import precedence.

--- a/flagscale/models/kerv/ops/__init__.py
+++ b/flagscale/models/kerv/ops/__init__.py
@@ -1,0 +1,83 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bundled KERV runtime optimizations.
+
+KERV imports its optimized runtime as the top-level package
+``KERVRuntimeOptimization``. FlagScale keeps that package below this module
+so the model integration remains self-contained while preserving KERV's
+public import contract.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def bundled_runtime_path() -> Path:
+    """Return the directory that contains ``KERVRuntimeOptimization``."""
+
+    return Path(__file__).resolve().parent
+
+
+def load_embodied_ops() -> ModuleType:
+    """Load the bundled operator module through KERV's canonical name."""
+
+    runtime_path = str(bundled_runtime_path())
+    if runtime_path not in sys.path:
+        sys.path.insert(0, runtime_path)
+    return importlib.import_module("KERVRuntimeOptimization.embodied_ops")
+
+
+_EMBODIED_EXPORTS = (
+    "configure_kerv_ops",
+    "install_static_tree_attention",
+    "kerv_action_projection_select",
+    "kerv_action_verify_accept",
+    "kerv_add_rms_norm",
+    "kerv_down_proj_residual_rms_norm",
+    "kerv_draft_action_topk",
+    "kerv_kv_accept_commit",
+    "kerv_kv_commit",
+    "kerv_logical_kv_commit",
+    "kerv_o_proj_residual_rms_norm",
+    "kerv_ops_manifest",
+    "kerv_rope_kv_store",
+    "kerv_silu_mul",
+    "kerv_static_tree_attention",
+    "kerv_static_tree_pack",
+    "kerv_tree_embed_pack",
+    "kerv_value_cache_store",
+    "kerv_verify_accept_control",
+    "kerv_vision_add_layer_norm",
+    "kerv_vision_bias_gelu",
+    "register_kerv_ops",
+    "static_tree_attention",
+    "static_tree_attention_reference",
+)
+
+
+def __getattr__(name: str):
+    if name in _EMBODIED_EXPORTS:
+        return getattr(load_embodied_ops(), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["bundled_runtime_path", "load_embodied_ops", *_EMBODIED_EXPORTS]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ include = ["flagscale*"]
 
 [tool.setuptools.package-data]
 "flagscale" = ["**/*.yaml", "**/*.yml"]
+"flagscale.models.kerv.ops" = ["README.md"]
+"flagscale.models.kerv.ops.KERVRuntimeOptimization.embodied_ops" = ["operator_manifest.json"]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,6 @@ include = ["flagscale*"]
 
 [tool.setuptools.package-data]
 "flagscale" = ["**/*.yaml", "**/*.yml"]
-"flagscale.models.kerv.ops" = ["README.md"]
-"flagscale.models.kerv.ops.KERVRuntimeOptimization.embodied_ops" = ["operator_manifest.json"]
 
 [tool.ruff]
 line-length = 100

--- a/tests/unit_tests/models/kerv/test_inprocess_entrypoint.py
+++ b/tests/unit_tests/models/kerv/test_inprocess_entrypoint.py
@@ -1,6 +1,7 @@
 # Copyright 2026 FlagOS Contributors
 # Licensed under the Apache License, Version 2.0.
 
+import importlib.machinery
 import os
 import sys
 from pathlib import Path
@@ -11,9 +12,11 @@ from omegaconf import OmegaConf
 from flagscale.inference.inference_kerv import main as inference_main
 from flagscale.models.kerv.entrypoint import (
     KERVEntrypointError,
+    _python_paths,
     build_inprocess_argv,
     run_kerv_entrypoint,
 )
+from flagscale.models.kerv.ops import bundled_runtime_path
 from flagscale.train.train_kerv import main as train_main
 
 
@@ -74,6 +77,67 @@ def test_build_inprocess_argv_matches_upstream_cli_contract():
         "--threshold",
         "4",
     ]
+
+
+def test_bundled_runtime_precedes_source_checkout(tmp_path):
+    root = tmp_path / "KERV"
+    external_runtime = root / "runtime_opt"
+    external_package = external_runtime / "KERVRuntimeOptimization"
+    external_package.mkdir(parents=True)
+    (external_package / "__init__.py").write_text("ORIGIN = 'external'\n", encoding="utf-8")
+    config = _config(
+        root,
+        "entry.py:main",
+        python_paths=[str(external_runtime)],
+    )
+
+    paths = _python_paths(config, root)
+    spec = importlib.machinery.PathFinder.find_spec("KERVRuntimeOptimization", paths)
+
+    assert paths[0] == str(bundled_runtime_path())
+    assert spec is not None
+    assert spec.origin is not None
+    assert Path(spec.origin).is_relative_to(bundled_runtime_path())
+
+
+def test_kerv_entrypoint_imports_bundled_optimization_runtime(tmp_path):
+    root = tmp_path / "KERV"
+    external_runtime = root / "runtime_opt"
+    external_package = external_runtime / "KERVRuntimeOptimization"
+    external_package.mkdir(parents=True)
+    (external_package / "__init__.py").write_text(
+        "raise RuntimeError('external runtime must not be imported')\n",
+        encoding="utf-8",
+    )
+    entrypoint = root / "entry.py"
+    entrypoint.write_text(
+        "def main():\n"
+        "    import KERVRuntimeOptimization\n"
+        "    from KERVRuntimeOptimization import adaptive_linear_fusion\n"
+        "    from KERVRuntimeOptimization import adaptive_rms_norm\n"
+        "    from KERVRuntimeOptimization import adaptive_rotary_fusion\n"
+        "    from KERVRuntimeOptimization import fused_logsoftmax_topk\n"
+        "    from KERVRuntimeOptimization import rotary_cache\n"
+        "    from KERVRuntimeOptimization import tree_attention_mask\n"
+        "    from KERVRuntimeOptimization import embodied_ops\n"
+        "    return [module.__file__ for module in (\n"
+        "        KERVRuntimeOptimization, adaptive_linear_fusion,\n"
+        "        adaptive_rms_norm, adaptive_rotary_fusion,\n"
+        "        fused_logsoftmax_topk, rotary_cache,\n"
+        "        tree_attention_mask, embodied_ops)]\n",
+        encoding="utf-8",
+    )
+    config = _config(
+        root,
+        "entry.py:main",
+        python_paths=[str(external_runtime)],
+        dependencies=["KERVRuntimeOptimization"],
+    )
+
+    module_paths = run_kerv_entrypoint(config)
+
+    assert len(module_paths) == 8
+    assert all(Path(path).is_relative_to(bundled_runtime_path()) for path in module_paths)
 
 
 def test_script_function_runs_in_current_process_and_restores_context(tmp_path):

--- a/tests/unit_tests/models/kerv/test_launcher.py
+++ b/tests/unit_tests/models/kerv/test_launcher.py
@@ -61,7 +61,9 @@ def test_python_command_and_argument_rendering(tmp_path):
     assert command[1] == str(script)
     assert command[-4:] == ["--enabled", "True", "--buckets", "224,240"]
     assert work_dir == tmp_path
-    assert environment["PYTHONPATH"].split(":")[0] == str(tmp_path)
+    python_paths = environment["PYTHONPATH"].split(":")
+    assert python_paths[0].endswith("flagscale/models/kerv/ops")
+    assert python_paths[1] == str(tmp_path)
 
 
 def test_workdir_and_python_paths_are_absolute(tmp_path, monkeypatch):
@@ -82,7 +84,7 @@ def test_workdir_and_python_paths_are_absolute(tmp_path, monkeypatch):
     )
     _, work_dir, environment = build_kerv_command(config)
     assert work_dir == tmp_path
-    assert environment["PYTHONPATH"].split(":")[:2] == [
+    assert environment["PYTHONPATH"].split(":")[1:3] == [
         str(source_root),
         str(runtime_root),
     ]

--- a/tests/unit_tests/models/kerv/test_ops.py
+++ b/tests/unit_tests/models/kerv/test_ops.py
@@ -1,0 +1,301 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import sys
+
+import pytest
+import torch
+
+from flagscale.models.kerv.ops import (
+    bundled_runtime_path,
+    configure_kerv_ops,
+    kerv_action_projection_select,
+    kerv_action_verify_accept,
+    kerv_add_rms_norm,
+    kerv_down_proj_residual_rms_norm,
+    kerv_draft_action_topk,
+    kerv_kv_accept_commit,
+    kerv_kv_commit,
+    kerv_logical_kv_commit,
+    kerv_o_proj_residual_rms_norm,
+    kerv_rope_kv_store,
+    kerv_silu_mul,
+    kerv_static_tree_pack,
+    kerv_tree_embed_pack,
+    kerv_value_cache_store,
+    kerv_verify_accept_control,
+    kerv_vision_add_layer_norm,
+    kerv_vision_bias_gelu,
+    static_tree_attention,
+    static_tree_attention_reference,
+)
+
+
+def test_complete_runtime_imports_without_triton():
+    modules = (
+        "adaptive_linear_fusion",
+        "adaptive_rms_norm",
+        "adaptive_rotary_fusion",
+        "embodied_ops",
+        "fused_logsoftmax_topk",
+        "rotary_cache",
+        "tree_attention_mask",
+    )
+    script = (
+        "import importlib, sys; "
+        "sys.modules['triton'] = None; "
+        f"modules = {modules!r}; "
+        "[importlib.import_module('KERVRuntimeOptimization.' + name) for name in modules]"
+    )
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (str(bundled_runtime_path()), environment.get("PYTHONPATH", ""))
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_public_namespace_and_cpu_fallbacks():
+    gate = torch.randn(2, 8)
+    up = torch.randn_like(gate)
+    expected = torch.nn.functional.silu(gate.clone()) * up
+    result = kerv_silu_mul(gate, up)
+    torch.testing.assert_close(result, expected)
+
+    hidden = torch.randn(2, 8)
+    residual = torch.randn_like(hidden)
+    weight = torch.randn(8)
+    expected = torch.nn.functional.rms_norm(hidden + residual, (8,), weight, 1e-6)
+    result = kerv_add_rms_norm(hidden, residual, weight, 1e-6)
+    torch.testing.assert_close(result, expected)
+
+    logits = torch.randn(3, 5, 17)
+    candidates = torch.randint(0, 17, (3, 5))
+    best, length = kerv_verify_accept_control(logits, candidates, 0.0, 0)
+    predicted = logits[:, :-1].argmax(-1)
+    accepted = torch.cumprod((candidates[:, 1:] == predicted).int(), dim=1).sum(dim=1)
+    assert torch.equal(best, accepted.argmax())
+    assert torch.equal(length, accepted.max())
+
+    draft = torch.arange(12).reshape(1, 12)
+    kept = torch.tensor([0, 3, 7])
+    packed = kerv_static_tree_pack(draft, kept, 5)
+    assert packed.tolist() == [[0, 3, 7, 0, 0]]
+
+    hidden = torch.randn(2, 8)
+    weight = torch.randn(11, 8)
+    expected_ids = torch.nn.functional.linear(hidden, weight).argmax(dim=-1) + 100
+    torch.testing.assert_close(kerv_action_projection_select(hidden, weight, 100), expected_ids)
+
+    destination = torch.zeros(1, 2, 8, 4)
+    source = torch.ones(1, 2, 3, 4)
+    kerv_kv_commit(destination, source, 2)
+    assert torch.equal(destination[..., 2:5, :], source)
+
+    cache = torch.zeros(1, 2, 8, 4)
+    kerv_value_cache_store(cache, source, 1)
+    assert torch.equal(cache[..., 1:4, :], source)
+
+
+def test_static_tree_attention_cpu_reference():
+    query = torch.randn(1, 2, 3, 4)
+    key = torch.randn(1, 2, 5, 4)
+    value = torch.randn(1, 2, 5, 4)
+    ancestors = torch.tensor([[0, 1], [0, 2], [0, 4]])
+    result = static_tree_attention(query, key, value, ancestors, 2)
+    expected = static_tree_attention_reference(query, key, value, ancestors, 2)
+    torch.testing.assert_close(result, expected)
+
+
+def test_phase2_public_interfaces_cpu_native():
+    """Exercise every phase-two schema without requiring CUDA/Triton."""
+    configure_kerv_ops(
+        enabled=True,
+        backend="native",
+        include=(
+            "kerv_tree_embed_pack,kerv_rope_kv_store,kerv_action_verify_accept,"
+            "kerv_draft_action_topk,kerv_kv_accept_commit,kerv_vision_add_layer_norm,"
+            "kerv_vision_bias_gelu,kerv_o_proj_residual_rms_norm,"
+            "kerv_down_proj_residual_rms_norm,kerv_logical_kv_commit"
+        ),
+    )
+
+    tokens = torch.tensor([[2, 5, 7, 11]])
+    keep = torch.tensor([0, 2])
+    embedding = torch.randn(16, 8)
+    packed = kerv_tree_embed_pack(tokens, keep, embedding, 3)
+    expected_ids = torch.tensor([[2, 7, 2]])
+    torch.testing.assert_close(packed, embedding[expected_ids])
+
+    query = torch.randn(1, 2, 3, 128)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    cos = torch.randn(1, 3, 128)
+    sin = torch.randn_like(cos)
+    key_cache = torch.zeros(1, 2, 12, 128)
+    value_cache = torch.zeros_like(key_cache)
+    rotated = kerv_rope_kv_store(
+        query, key, value, cos, sin, torch.empty(0, dtype=torch.long), key_cache, value_cache, 4
+    )
+    assert rotated.shape == query.shape
+    torch.testing.assert_close(value_cache[:, :, 4:7], value)
+
+    hidden = torch.randn(6, 8)
+    action_weight = torch.randn(32, 8)
+    candidates = torch.randint(0, 32, (2, 3))
+    best, length, next_token = kerv_action_verify_accept(hidden, action_weight, candidates, 0.0, 0)
+    logits = torch.nn.functional.linear(hidden, action_weight).reshape(2, 3, 32)
+    predicted = logits.argmax(-1)
+    accepted = torch.cumprod((predicted[:, :-1] == candidates[:, 1:]).to(torch.int32), dim=1).sum(
+        -1
+    )
+    assert torch.equal(best, accepted.argmax())
+    assert torch.equal(length, accepted[best])
+    assert torch.equal(next_token, predicted[best, length.clamp_max(2)])
+
+    values, indices = kerv_draft_action_topk(hidden, action_weight, 100, 4)
+    ref_values, ref_indices = torch.sort(
+        torch.nn.functional.log_softmax(logits.reshape(-1, 32)[0].float(), dim=-1),
+        dim=-1,
+        descending=True,
+        stable=True,
+    )
+    torch.testing.assert_close(values[0], ref_values[:4].to(values.dtype))
+    assert torch.equal(indices[0], ref_indices[:4] + 100)
+
+    storage = torch.zeros(2, 2, 1, 2, 16, 4)
+    source = torch.randn_like(storage[..., :3, :])
+    storage[..., 6:9, :].copy_(source)
+    indices = torch.tensor([2, 0, 1])
+    expected = storage[..., 6 + indices, :].clone()
+    scratch = torch.empty_like(expected)
+    kerv_kv_accept_commit(storage, indices, 6, scratch=scratch)
+    torch.testing.assert_close(storage[..., 6:9, :], expected)
+
+    x = torch.randn(4, 8)
+    residual = torch.randn_like(x)
+    norm_weight = torch.randn(8)
+    bias = torch.randn(8)
+    norm = kerv_vision_add_layer_norm(x, residual, norm_weight, bias, 1e-5)
+    expected_norm = torch.nn.functional.layer_norm(x + residual, (8,), norm_weight, bias, 1e-5)
+    torch.testing.assert_close(norm, expected_norm)
+    gelu = kerv_vision_bias_gelu(x, bias)
+    torch.testing.assert_close(gelu, torch.nn.functional.gelu(x + bias, approximate="none"))
+
+    proj = torch.randn(8, 8)
+    rms = torch.randn(8)
+    for op in (kerv_o_proj_residual_rms_norm, kerv_down_proj_residual_rms_norm):
+        value = op(x, proj, residual, rms, 1e-5, bias)
+        expected_value = torch.nn.functional.rms_norm(
+            torch.nn.functional.linear(x, proj, bias) + residual,
+            (8,),
+            rms,
+            1e-5,
+        )
+        torch.testing.assert_close(value, expected_value)
+
+    logical = torch.zeros(12, dtype=torch.long)
+    result = kerv_logical_kv_commit(logical, torch.tensor([8, 4]), 3)
+    assert result.tolist() == [0, 0, 0, 8, 4, 0, 0, 0, 0, 0, 0, 0]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_verify_accept_cuda_matches_aten():
+    logits = torch.randn(49, 9, 256, device="cuda", dtype=torch.bfloat16)
+    candidates = torch.randint(0, 256, (49, 9), device="cuda")
+    result = kerv_verify_accept_control(logits, candidates, 0.0, 0)
+    predicted = logits[:, :-1].argmax(-1)
+    accepted = torch.cumprod((candidates[:, 1:] == predicted).int(), dim=1).sum(dim=1)
+    assert torch.equal(result[0], accepted.argmax())
+    assert torch.equal(result[1], accepted.max())
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_static_tree_attention_cuda_matches_reference():
+    # Build a duplicate-free binary ancestor chain for the tree portion.  The
+    # production KERV templates have the same invariant.
+    from flagscale.models.kerv.ops import configure_kerv_ops
+
+    configure_kerv_ops(
+        enabled=True,
+        include="kerv_static_tree_attention",
+        backend="triton",
+    )
+    for depth in (4, 5, 8):
+        query = torch.randn(1, 2, 64, 128, device="cuda", dtype=torch.bfloat16)
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+        ancestors = torch.full((64, depth), -1, device="cuda", dtype=torch.long)
+        for row in range(32, 64):
+            chain = []
+            node = row
+            while node >= 32 and len(chain) < depth:
+                chain.append(node)
+                node = 32 + (node - 33) // 2 if node >= 33 else -1
+            ancestors[row, : len(chain)] = torch.tensor(chain, device="cuda")
+        result = static_tree_attention(query, key, value, ancestors, 32)
+        expected = static_tree_attention_reference(query, key, value, ancestors, 32)
+        torch.testing.assert_close(result, expected, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_static_tree_attention_fixed_prefix_gap_matches_reference():
+    """Unused fixed-prefix slots must never participate in tree attention."""
+    configure_kerv_ops(
+        enabled=True,
+        include="kerv_static_tree_attention",
+        backend="triton",
+    )
+    tree_start, valid_prefix, tree_nodes = 288, 279, 64
+    query = torch.randn(1, 2, tree_nodes, 128, device="cuda", dtype=torch.bfloat16)
+    key = torch.randn(
+        1,
+        2,
+        tree_start + tree_nodes,
+        128,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    value = torch.randn_like(key)
+    ancestors = torch.full((tree_nodes, 8), -1, device="cuda", dtype=torch.long)
+    for row in range(tree_nodes):
+        start = max(0, row - 7)
+        nodes = torch.arange(start, row + 1, device="cuda") + tree_start
+        ancestors[row, : nodes.numel()] = nodes
+    valid_prefix_tensor = torch.tensor(valid_prefix, device="cuda", dtype=torch.int32)
+    result = static_tree_attention(
+        query,
+        key,
+        value,
+        ancestors,
+        tree_start,
+        valid_prefix_tokens=valid_prefix_tensor,
+    )
+    expected = static_tree_attention_reference(
+        query,
+        key,
+        value,
+        ancestors,
+        tree_start,
+        valid_prefix_tokens=valid_prefix_tensor,
+    )
+    torch.testing.assert_close(result, expected, rtol=2e-2, atol=2e-2)

--- a/tests/unit_tests/models/kerv/test_optimization_runtime.py
+++ b/tests/unit_tests/models/kerv/test_optimization_runtime.py
@@ -76,6 +76,13 @@ def test_adaptive_rotary_matches_reference():
 
 def test_fused_logsoftmax_topk_matches_pytorch():
     logits = torch.randn(2, 32064, device="cuda", dtype=torch.bfloat16)
+    # BF16 random logits contain many ties, and CUDA topk does not guarantee
+    # the order of equal elements across separate launches. Keep the tested
+    # top-k unique so this comparison checks the operator rather than tie
+    # scheduling in two independent native topk calls.
+    top_indices = torch.tensor([3, 17, 101, 509, 1021, 4093, 8191, 16381], device="cuda")
+    top_values = torch.tensor([32, 30, 28, 26, 24, 22, 20, 18], device="cuda", dtype=logits.dtype)
+    logits[:, top_indices] = top_values
 
     values, indices = fused_logsoftmax_topk(logits, 8)
     expected_values, expected_indices = torch.topk(

--- a/tests/unit_tests/models/kerv/test_optimization_runtime.py
+++ b/tests/unit_tests/models/kerv/test_optimization_runtime.py
@@ -1,0 +1,145 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+
+import pytest
+import torch
+import torch.nn as nn
+
+from flagscale.models.kerv.ops import load_embodied_ops
+
+load_embodied_ops()
+
+fuse_transformer_linears = importlib.import_module(
+    "KERVRuntimeOptimization.adaptive_linear_fusion"
+).fuse_transformer_linears
+rms_norm_inference = importlib.import_module(
+    "KERVRuntimeOptimization.adaptive_rms_norm"
+).rms_norm_inference
+fused_rotary_qk = importlib.import_module(
+    "KERVRuntimeOptimization.adaptive_rotary_fusion"
+).fused_rotary_qk
+fused_logsoftmax_topk = importlib.import_module(
+    "KERVRuntimeOptimization.fused_logsoftmax_topk"
+).fused_logsoftmax_topk
+build_tree_causal_mask = importlib.import_module(
+    "KERVRuntimeOptimization.tree_attention_mask"
+).build_tree_causal_mask
+
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+
+
+def test_adaptive_rms_norm_matches_kerv_rounding():
+    value = torch.randn(8, 4096, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(4096, device="cuda", dtype=torch.bfloat16)
+
+    result = rms_norm_inference(value, (4096,), weight, 1e-6)
+    inverse_rms = torch.rsqrt(value.float().square().mean(-1, keepdim=True) + 1e-6)
+    expected = (value.float() * inverse_rms).to(value.dtype) * weight
+
+    torch.testing.assert_close(result, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_adaptive_rotary_matches_reference():
+    query = torch.randn(1, 32, 8, 128, device="cuda", dtype=torch.bfloat16)
+    key = torch.randn(1, 8, 8, 128, device="cuda", dtype=torch.bfloat16)
+    cosine = torch.randn(1, 1, 64, 128, device="cuda", dtype=torch.bfloat16)
+    sine = torch.randn_like(cosine)
+    positions = torch.arange(8, device="cuda").unsqueeze(0)
+
+    result_query, result_key = fused_rotary_qk(query, key, cosine, sine, positions)
+    selected_cosine = cosine[0, 0].index_select(0, positions[0]).unsqueeze(0).unsqueeze(1)
+    selected_sine = sine[0, 0].index_select(0, positions[0]).unsqueeze(0).unsqueeze(1)
+
+    def rotate_half(value):
+        half = value.shape[-1] // 2
+        return torch.cat((-value[..., half:], value[..., :half]), dim=-1)
+
+    expected_query = query * selected_cosine + rotate_half(query) * selected_sine
+    expected_key = key * selected_cosine + rotate_half(key) * selected_sine
+    torch.testing.assert_close(result_query, expected_query, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(result_key, expected_key, rtol=2e-2, atol=2e-2)
+
+
+def test_fused_logsoftmax_topk_matches_pytorch():
+    logits = torch.randn(2, 32064, device="cuda", dtype=torch.bfloat16)
+
+    values, indices = fused_logsoftmax_topk(logits, 8)
+    expected_values, expected_indices = torch.topk(
+        torch.nn.functional.log_softmax(logits, dim=-1), 8, dim=-1
+    )
+
+    assert torch.equal(indices, expected_indices)
+    torch.testing.assert_close(values, expected_values, rtol=2e-2, atol=2e-2)
+
+
+def test_tree_attention_mask_matches_reference():
+    tree_length = 48
+    past_length = 19
+    tree_mask = torch.tril(torch.ones(tree_length, tree_length, device="cuda", dtype=torch.bool))
+
+    result = build_tree_causal_mask(tree_mask, past_length, torch.bfloat16)
+    expected = torch.zeros_like(result)
+    expected[..., past_length:] = torch.where(
+        tree_mask,
+        torch.zeros((), device="cuda", dtype=torch.bfloat16),
+        torch.full((), torch.finfo(torch.bfloat16).min, device="cuda", dtype=torch.bfloat16),
+    )
+
+    assert torch.equal(result, expected)
+
+
+def test_packed_qkv_projection_preserves_outputs():
+    class Attention(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.q_proj = nn.Linear(16, 16, bias=True, device="cuda", dtype=torch.bfloat16)
+            self.k_proj = nn.Linear(16, 8, bias=True, device="cuda", dtype=torch.bfloat16)
+            self.v_proj = nn.Linear(16, 8, bias=True, device="cuda", dtype=torch.bfloat16)
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.attention = Attention()
+
+    model = Model()
+    value = torch.randn(4, 16, device="cuda", dtype=torch.bfloat16)
+    expected = tuple(
+        projection(value)
+        for projection in (
+            model.attention.q_proj,
+            model.attention.k_proj,
+            model.attention.v_proj,
+        )
+    )
+
+    manifest = fuse_transformer_linears(
+        model,
+        qkv_rows=(4,),
+        qkv_input_sizes=(16,),
+    )
+    result = tuple(
+        projection(value)
+        for projection in (
+            model.attention.q_proj,
+            model.attention.k_proj,
+            model.attention.v_proj,
+        )
+    )
+
+    assert manifest["qkv_group_count"] == 1
+    for candidate, reference in zip(result, expected):
+        torch.testing.assert_close(candidate, reference, rtol=2e-2, atol=2e-2)


### PR DESCRIPTION
## Summary

- Bundle the KERV runtime optimization package under `flagscale/models/kerv/ops`.
- Register 18 `torch.ops.flagos_embodied` interfaces and integrate the 14-interface KERV runtime profile.
- Route KERV training and inference entrypoints to the bundled operators before any external source tree.
- Add correctness tests, packaging checks, operator metadata, documentation, and an A100 microbenchmark.

## Operator status

- 14 interfaces are integrated into the KERV runtime profile.
- 3 interfaces remain explicitly experimental and are disabled by default.
- 1 compatibility interface is retained for Value Cache Store.
- The current A100 `auto` routes enable the optimized Static Tree Attention and RoPE-KV Store paths after correctness and performance gating. Other interfaces retain their integrated reference/native paths.

## Validation

- KERV unit suite on A100: `47 passed`.
- Official pre-commit hooks: all passed.
- `git diff --check`: passed.
- Wheel build and isolated installed-package import: passed; all 18 operator schemas register successfully.
- Full KERV model initialization reaches the optional LIBERO evaluator; the evaluator itself is kept outside CI because it requires a host EGL/MuJoCo rendering environment.

## Contributors

- Zihao Zheng (@zhengzihaoPKU)
- Zhihao Mao (@lusunn111, htxmzh@gmail.com)

Co-authored-by: Zhihao Mao <49109638+lusunn111@users.noreply.github.com>