### PR TITLE
[Train] Add Python 3.10/3.11 compatibility for hybrid override

### DIFF
--- a/flagscale/train/megatron/training/models/hybrid.py
+++ b/flagscale/train/megatron/training/models/hybrid.py
@@ -2,7 +2,12 @@
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Callable, ClassVar, Literal, override
+from typing import Any, Callable, ClassVar, Literal
+
+try:
+    from typing import override
+except ImportError:
+    from typing_extensions import override
 
 from megatron.core.distributed.distributed_data_parallel_config import DistributedDataParallelConfig
 from megatron.core.enums import ModelType


### PR DESCRIPTION
### PR Category

Train

### PR Types

Improvements

### PR Description

Add Python 3.10/3.11 compatibility for the `override` import in the hybrid model module, supporting the Python 3.10 environment used by Hygon training containers. FlagScale declares `requires-python = ">=3.10"`, while [`typing.override`](https://docs.python.org/3.12/library/typing.html#typing.override) is available starting in Python 3.12.

Fall back to `typing_extensions.override` when the standard-library import is unavailable. Python 3.12+ continues to use `typing.override`, and the existing `@override` decorators are preserved.

Validation on a Hygon training container with Python 3.10.12 and `typing_extensions` 4.15.0:

- Confirmed that the original import raises `ImportError`, and the updated import resolves to `typing_extensions.override`.
- Compiled and loaded the complete PR version of `hybrid.py` with the container's Megatron training dependencies. Both `HybridModelConfig` override decorators are preserved.
- `git diff --check` passed. The PR changes only the import preamble in `hybrid.py`.

Distributed GPU training was not rerun for this PR.
